### PR TITLE
Add support for BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ endif
 endif
 
 # Make tools if out of date
-DUMMY != make -s -C tools >&2 || echo FAIL
+DUMMY != $(MAKE) -s -C tools >&2 || echo FAIL
 ifeq ($(DUMMY),FAIL)
   $(error Failed to build tools)
 endif

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -152,9 +152,15 @@ def main():
             )
             sys.exit(1)
 
+    make = "make"
+
+    for path in os.environ["PATH"].split(os.pathsep):
+        if os.path.isfile(os.path.join(path, "gmake")):
+            make = "gmake"
+
     # Make sure tools exist
     subprocess.check_call(
-        ["make", "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]
+        [make, "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]
     )
 
     # Go through the assets in roughly alphabetical order (but assets in the same

--- a/src/pc/audio/audio_alsa.c
+++ b/src/pc/audio/audio_alsa.c
@@ -1,4 +1,6 @@
-#if defined(__linux__) && !defined(TARGET_WEB)
+#include "../compat.h"
+
+#if (defined(__linux__) || defined(__BSD__)) && !defined(TARGET_WEB)
 /*
     Simple sound playback using ALSA API and libasound.
     Dependencies: libasound, alsa

--- a/src/pc/audio/audio_alsa.h
+++ b/src/pc/audio/audio_alsa.h
@@ -1,7 +1,9 @@
 #ifndef AUDIO_ALSA_H
 #define AUDIO_ALSA_H
 
-#ifdef __linux__
+#include "../compat.h"
+
+#if defined(__linux__) || defined(__BSD__)
 extern struct AudioAPI audio_alsa;
 #define HAVE_ALSA 1
 #else

--- a/src/pc/audio/audio_pulse.c
+++ b/src/pc/audio/audio_pulse.c
@@ -1,4 +1,6 @@
-#ifdef __linux__
+#include "../compat.h"
+
+#if defined(__linux__) || defined(__BSD__)
 
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/pc/audio/audio_pulse.h
+++ b/src/pc/audio/audio_pulse.h
@@ -1,7 +1,9 @@
 #ifndef AUDIO_PULSE_H
 #define AUDIO_PULSE_H
 
-#ifdef __linux__
+#include "../compat.h"
+
+#if defined(__linux__) || defined(__BSD__)
 extern struct AudioAPI audio_pulse;
 #define HAVE_PULSE_AUDIO 1
 #else

--- a/src/pc/compat.h
+++ b/src/pc/compat.h
@@ -1,0 +1,8 @@
+#ifndef COMPAT_H
+#define COMPAT_H value
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#define __BSD__
+#endif
+
+#endif

--- a/src/pc/controller/wup.c
+++ b/src/pc/controller/wup.c
@@ -1,4 +1,4 @@
-#if !defined(__MINGW32__) && !defined(TARGET_WEB)
+#if !defined(__MINGW32__) && !defined(__BSD__) && !defined(TARGET_WEB)
 // See LICENSE for license
 
 #define _XOPEN_SOURCE 600

--- a/src/pc/gfx/gfx_glx.c
+++ b/src/pc/gfx/gfx_glx.c
@@ -1,4 +1,6 @@
-#ifdef __linux__
+#include "../compat.h"
+
+#if defined(__linux__) || defined(__BSD__)
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -1,4 +1,6 @@
-#if !defined(__linux__) && defined(ENABLE_OPENGL)
+#include "../compat.h"
+
+#if !defined(__linux__) && !defined(__BSD__) && defined(ENABLE_OPENGL)
 
 #ifdef __MINGW32__
 #define FOR_WINDOWS 1

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -29,6 +29,8 @@
 
 #include "configfile.h"
 
+#include "compat.h"
+
 #define CONFIG_FILE "sm64config.txt"
 
 OSMesg D_80339BEC;
@@ -158,7 +160,7 @@ void main_func(void) {
     wm_api = &gfx_dxgi_api;
 #elif defined(ENABLE_OPENGL)
     rendering_api = &gfx_opengl_api;
-    #if defined(__linux__)
+    #if defined(__linux__) || defined(__BSD__)
         wm_api = &gfx_glx;
     #else
         wm_api = &gfx_sdl;

--- a/tools/n64graphics_ci_dir/exoquant/exoquant.c
+++ b/tools/n64graphics_ci_dir/exoquant/exoquant.c
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 
 #include "exoquant.h"
-#include <malloc.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
various preprocessor checks have been added for BSD systems as well as a a compatibility header that defines a single uniform BSD preprocesor definition to reuse elsewhere.

Systems like FreeBSD still require GNU make since it ships with FreeBSD make instead