### PR TITLE
Reduced audio sample rate

### DIFF
--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -73,8 +73,8 @@ void send_display_list(struct SPTask *spTask) {
 #define SAMPLES_HIGH 656
 #define SAMPLES_LOW 640
 #else
-#define SAMPLES_HIGH 544
-#define SAMPLES_LOW 528
+#define SAMPLES_HIGH 528
+#define SAMPLES_LOW 512
 #endif
 
 void produce_one_frame(void) {


### PR DESCRIPTION
Applying the 60 fps enhancement patch causes the audio to crackle on
Windows. The WASAPI buffer is fed too quickly, causing
audio_wasapi_play() to drop audio frames due to a lack of buffer space.