### PR TITLE
SDL: Fix controller stick range

### DIFF
--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -88,9 +88,8 @@ static void controller_sdl_read(OSContPad *pad) {
 
     uint32_t magnitude_sq = (uint32_t)(leftx * leftx) + (uint32_t)(lefty * lefty);
     if (magnitude_sq > (uint32_t)(DEADZONE * DEADZONE)) {
-        pad->stick_x = leftx / 0x100;
-        int stick_y = -lefty / 0x100;
-        pad->stick_y = stick_y == 128 ? 127 : stick_y;
+        pad->stick_x = round((float) leftx) / 32768 * 80;
+        pad->stick_y = round((float) -lefty) / 32768 * 80;
     }
 }
 

--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -88,8 +88,8 @@ static void controller_sdl_read(OSContPad *pad) {
 
     uint32_t magnitude_sq = (uint32_t)(leftx * leftx) + (uint32_t)(lefty * lefty);
     if (magnitude_sq > (uint32_t)(DEADZONE * DEADZONE)) {
-        pad->stick_x = round((float) leftx) / 32768 * 80;
-        pad->stick_y = round((float) -lefty) / 32768 * 80;
+        pad->stick_x = round(((float) leftx) / 32768 * 80);
+        pad->stick_y = round(((float) -lefty) / 32768 * 80);
     }
 }
 


### PR DESCRIPTION
This fixes the range reported to the game to be within -80..80 instead of -128..127, like it works on the real N64.