### PR TITLE
Fix CFLAG for PowerPC platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,16 @@ endif
 GFX_CFLAGS += -DWIDESCREEN
 
 CC_CHECK := $(CC) -fsyntax-only -fsigned-char $(INCLUDE_CFLAGS) -Wall -Wextra -Wno-format-security -D_LANGUAGE_C $(VERSION_CFLAGS) $(MATCH_CFLAGS) $(PLATFORM_CFLAGS) $(GFX_CFLAGS) $(GRUCODE_CFLAGS)
-CFLAGS := $(OPT_FLAGS) $(INCLUDE_CFLAGS) -D_LANGUAGE_C $(VERSION_CFLAGS) $(MATCH_CFLAGS) $(PLATFORM_CFLAGS) $(GFX_CFLAGS) $(GRUCODE_CFLAGS) -fno-strict-aliasing -fwrapv -march=native
+CFLAGS := $(OPT_FLAGS) $(INCLUDE_CFLAGS) -D_LANGUAGE_C $(VERSION_CFLAGS) $(MATCH_CFLAGS) $(PLATFORM_CFLAGS) $(GFX_CFLAGS) $(GRUCODE_CFLAGS) -fno-strict-aliasing -fwrapv
+ifeq ($(TARGET_LINUX),1)
+  machine = $(shell sh -c 'uname -m 2>/dev/null || echo unknown')
+
+  ifneq (,$(findstring ppc,$(machine)))
+    CFLAGS += -mcpu=native
+  endif
+else
+  CFLAGS += -march=native
+endif
 
 ASFLAGS := -I include -I $(BUILD_DIR) $(VERSION_ASFLAGS)
 


### PR DESCRIPTION
## Context

There is no `-march` flag for PowerPC ( be it PowerPC32 or 64 LE / BE). Therefore the code won't compile and return following error:

```bash
cpp -P -DVERSION_US -I . -o build/us_pc/level_rules.mk levels/level_rules.mk
gcc -c -O2 -I include -I build/us_pc -I build/us_pc/include -I src -I . -D_LANGUAGE_C -DVERSION_US -DNON_MATCHING -DAVOID_UB -DTARGET_LINUX `pkg-config --cflags libusb-1.0` -DNO_SEGMENTED_MEMORY -DENABLE_OPENGL -I/usr/include/SDL2 -D_REENTRANT -DWIDESCREEN -DF3DEX_GBI_2E -fno-strict-aliasing -fwrapv -march=native -o build/us_pc/src/engine/behavior_script.o src/engine/behavior_script.c
gcc: error: unrecognized command-line option ‘-march=native’; did you mean ‘-mcpu=native’?
make: *** [Makefile:787: build/us_pc/src/engine/behavior_script.o] Error 1
```

![](https://forums.raptorcs.com/index.php?action=dlattach;topic=208.0;attach=222;image)

## Changes

* Add a condition to set the flag correctly 