### PR TITLE
Add ability to compile on HaikuOS

### DIFF
--- a/include/PR/os_libc.h
+++ b/include/PR/os_libc.h
@@ -4,7 +4,9 @@
 #include "ultratypes.h"
 
 // Old deprecated functions from strings.h, replaced by memcpy/memset.
+#ifndef bcopy // bcopy and bzero are sometimes defined as macros for memcpy and memset
 extern void bcopy(const void *, void *, size_t);
 extern void bzero(void *, size_t);
+#endif
 
 #endif /* !_OS_LIBC_H_ */

--- a/src/pc/controller/wup.c
+++ b/src/pc/controller/wup.c
@@ -1,4 +1,4 @@
-#if !defined(__MINGW32__) && !defined(__BSD__) && !defined(TARGET_WEB)
+#if !defined(__MINGW32__) && !defined(__BSD__) && !defined(__HAIKU__) && !defined(TARGET_WEB)
 // See LICENSE for license
 
 #define _XOPEN_SOURCE 600

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -14,7 +14,7 @@
 #define FOR_WINDOWS 0
 #endif
 
-#if FOR_WINDOWS
+#if USE_GLEW
 #include <GL/glew.h>
 #include "SDL.h"
 #define GL_GLEXT_PROTOTYPES 1
@@ -472,7 +472,7 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
 }
 
 static void gfx_opengl_init(void) {
-#if FOR_WINDOWS
+#if USE_GLEW
     glewInit();
 #endif
     

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -8,7 +8,7 @@
 #define FOR_WINDOWS 0
 #endif
 
-#if FOR_WINDOWS
+#if USE_GLEW
 #include <GL/glew.h>
 #include "SDL.h"
 #define GL_GLEXT_PROTOTYPES 1


### PR DESCRIPTION
This PR has been tried on the following systems

| OS | Arch | Compilerc |
| --------------- | --------------- | --------------- |
| Fedora 32 | x86_64 | gcc, clang |
| Fedora 33 | x86_64 | gcc |
| Haiku r1beta2 | x86_64 | gcc, clang |
| Haiku Nighly Revision 54807 | x86_64 | gcc |

Here is a list of changes that has been done with reasoning for some of them:
- adds TARGET_HAIKU and non NT OS detecting logic.
- explicit linking has been replaced with calls to pkg-config for systems that have non default locations for libraries.
    - pkg-config is still called with backticks for platform linker flags. This allows the calls to fail and the Makefile to continue execution though it could be replaced with the shell directive if desired.
- replace GLEW related includes, code, etc. that checked explicitly for Windows  to check for USE_GLEW instead.
    - HaikuOS does not have a GLES2 implementation (though the SDL2 port ships with the GLES2 header) so falling back to GLEW is the better choice right now.
    - Moving from explicit Windows checks from USE_GLEW checks was done to clean the code up a bit and make it easier for other systems to rely on
- put a macro guard around the bcopy, bzero definitions.
    - Clang on HaikuOS has reported that bcopy and bzero were defined as macros to memcpy and memset respectively breaking the definitions during macro resolution
    - only bcopy is checked upon since how likely is it only *one* of them but perhaps both should be checked
 - no working audio
    - Haiku doesn't have pulseaudio or alsa since its not built upon the Linux kernel
    - using the SDL2 audio backend works fine but feedback is needed to decide if that is going to be enabled for Haiku

Notes:
- Haiku seems to lack vsync
- the cursor and the game fight over rendering though this is only a minor annoyance
- depends on nothing except SDL2, GLEW and a OpenGL implementation (like mesa)

Instructions to build on Haiku Nighly Revision 54807
```bash
# update the system`and reboot
~> pkgman update
~> shutdown -r

# install dependencies
~> pkgman install libsdl2 libsdl2_devel
~> pkgman install glew glew_devel
~> pkgman install python3 git
~> pkgman install util_linux

# clone PR
~> git clone https://github.com/Jan200101/sm64-port -b haikuos --single-branch
# somehow get a sm64 us rom over to Haiku. I used ssh but this is up to you
~> make
```