### PR TITLE
Fix controller left stick ranges

### DIFF
--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -88,9 +88,10 @@ static void controller_sdl_read(OSContPad *pad) {
 
     uint32_t magnitude_sq = (uint32_t)(leftx * leftx) + (uint32_t)(lefty * lefty);
     if (magnitude_sq > (uint32_t)(DEADZONE * DEADZONE)) {
-        pad->stick_x = leftx / 0x100;
-        int stick_y = -lefty / 0x100;
-        pad->stick_y = stick_y == 128 ? 127 : stick_y;
+        // Game expects stick coordinates within -80..80
+        // 32768 / 409 = ~80
+        pad->stick_x = leftx / 409;
+        pad->stick_y = -lefty / 409;
     }
 }
 

--- a/src/pc/controller/controller_xinput.c
+++ b/src/pc/controller/controller_xinput.c
@@ -33,8 +33,10 @@ static void xinput_read(OSContPad *pad) {
 
             uint32_t magnitude_sq = (uint32_t)(gp->sThumbLX * gp->sThumbLX) + (uint32_t)(gp->sThumbLY * gp->sThumbLY);
             if (magnitude_sq > (uint32_t)(DEADZONE * DEADZONE)) {
-                pad->stick_x = gp->sThumbLX / 0x100;
-                pad->stick_y = gp->sThumbLY / 0x100;
+                // Game expects stick coordinates within -80..80
+                // 32768 / 409 = ~80
+                pad->stick_x = gp->sThumbLX / 409;
+                pad->stick_y = gp->sThumbLY / 409;
             }
             break;
         }


### PR DESCRIPTION
This fixes the range of the left stick to be -80..80 for SDL2 and XInput, as those are the values the game expects. Separate PR because I couldn't seem to push to the other one.

Something we might want to do in addition to this is get rid of the deadzone for SDL2/XInput, as the game already has a builtin deadzone between -8..8, so 10%, which seems like it should be enough on its own.