### PR TITLE
Exit on window close on Linux.

### DIFF
--- a/src/pc/gfx/gfx_glx.c
+++ b/src/pc/gfx/gfx_glx.c
@@ -411,6 +411,8 @@ static void gfx_glx_get_dimensions(uint32_t *width, uint32_t *height) {
 }
 
 static void gfx_glx_handle_events(void) {
+    Atom wm_delete_window = XInternAtom(glx.dpy, "WM_DELETE_WINDOW", 0);
+    XSetWMProtocols(glx.dpy, glx.win, & wm_delete_window, 1);
     while (XPending(glx.dpy)) {
         XEvent xev;
         XNextEvent(glx.dpy, &xev);
@@ -436,6 +438,11 @@ static void gfx_glx_handle_events(void) {
                         }
                     }
                 }
+            }
+        }
+        if (xev.type == ClientMessage) {
+            if (xev.xclient.data.l[0] == wm_delete_window) {
+                exit(0);
             }
         }
     }


### PR DESCRIPTION
The game does not seem to exit when you close the window on Linux. It hangs on "Reseting timer". This PR will add the code to exit the game. The code has taken inspiration from this [example](https://github.com/derekdai/xdk/blob/master/examples/simple-window-wm-delete-window.c) and these two lines of code: https://github.com/sm64-port/sm64-port/blob/2ed7dfe046395c9a5bd11f771fa5b0355a7155c8/src/pc/gfx/gfx_sdl2.c#L265-L266.