### PR TITLE
Add SDL2 platform, quit via ALT+F4 and hide mouse cursor when fullscreen.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,12 +510,17 @@ ifeq ($(ENABLE_OPENGL),1)
     GFX_LDFLAGS += -lGL $(shell sdl2-config --libs) -lX11 -lXrandr
   endif
   ifeq ($(TARGET_SDL2),1)
-    # SDL2 can use either GL or GLES2
     GFX_CFLAGS  += -DUSE_SDL=2
-    ifeq ($(USE_GLES),1)
-      GFX_LDFLAGS += -lGLESv2 -lSDL2 -DUSE_GLES
+    ifndef _WIN32
+      # On most OSes, SDL2 can use either GL or GLES2
+      ifeq ($(USE_GLES),1)
+        GFX_LDFLAGS += -lGLESv2 -lSDL2 -DUSE_GLES
+      else
+        GFX_LDFLAGS += -lGL -lSDL2
+      endif
     else
-      GFX_LDFLAGS += -lGL -lSDL2
+        # On Windows, simply use OpenGL
+        GFX_LDFLAGS += $(shell sdl2-config --libs) -lopengl32
     endif
   endif
   ifeq ($(TARGET_WEB),1)

--- a/Makefile
+++ b/Makefile
@@ -511,16 +511,16 @@ ifeq ($(ENABLE_OPENGL),1)
   endif
   ifeq ($(TARGET_SDL2),1)
     GFX_CFLAGS  += -DUSE_SDL=2
-    ifndef _WIN32
-      # On most OSes, SDL2 can use either GL or GLES2
+    ifeq ($(OS),Windows_NT)
+        # On Windows, simply use OpenGL
+        GFX_LDFLAGS += $(shell sdl2-config --libs) -lopengl32
+    else
+      # On other OSes, SDL2 can use either GL or GLES2
       ifeq ($(USE_GLES),1)
         GFX_LDFLAGS += -lGLESv2 -lSDL2 -DUSE_GLES
       else
         GFX_LDFLAGS += -lGL -lSDL2
       endif
-    else
-        # On Windows, simply use OpenGL
-        GFX_LDFLAGS += $(shell sdl2-config --libs) -lopengl32
     endif
   endif
   ifeq ($(TARGET_WEB),1)

--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ ifeq ($(TARGET_LINUX),1)
 endif
 ifeq ($(TARGET_SDL2),1)
   PLATFORM_CFLAGS  := -DTARGET_SDL2
-  PLATFORM_LDFLAGS := -lm -lpthread -lasound -no-pie
+  PLATFORM_LDFLAGS := -lm -lpthread -no-pie
 endif
 ifeq ($(TARGET_WEB),1)
   PLATFORM_CFLAGS  := -DTARGET_WEB

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ DEFINES :=
 TARGET_N64 ?= 0
 # Build for Emscripten/WebGL
 TARGET_WEB ?= 0
-# Compiler to use (ido or gcc)
-
+# Build for SDL2 (No specific windwing API required, will run on whatever API SDL2 runs on)
+TARGET_SDL2 ?= 0
+# Build against OpenGL_ES2 instead of desktop OpenGL
+USE_GLES ?= 0
 
 # COMPILER - selects the C compiler to use
 #   ido - uses the SGI IRIS Development Option compiler, which is used to build
@@ -36,12 +38,15 @@ ifeq ($(TARGET_N64),0)
   NON_MATCHING := 1
   GRUCODE := f3dex2e
   TARGET_WINDOWS := 0
-  ifeq ($(TARGET_WEB),0)
-    ifeq ($(OS),Windows_NT)
-      TARGET_WINDOWS := 1
-    else
-      # TODO: Detect Mac OS X, BSD, etc. For now, assume Linux
-      TARGET_LINUX := 1
+
+  ifeq ($(TARGET_SDL2),0)
+    ifeq ($(TARGET_WEB),0)
+      ifeq ($(OS),Windows_NT)
+        TARGET_WINDOWS := 1
+      else
+        # TODO: Detect Mac OS X, BSD, etc. For now, assume Linux
+        TARGET_LINUX := 1
+      endif
     endif
   endif
 
@@ -481,6 +486,10 @@ ifeq ($(TARGET_LINUX),1)
   PLATFORM_CFLAGS  := -DTARGET_LINUX `pkg-config --cflags libusb-1.0`
   PLATFORM_LDFLAGS := -lm -lpthread `pkg-config --libs libusb-1.0` -lasound -lpulse -no-pie
 endif
+ifeq ($(TARGET_SDL2),1)
+  PLATFORM_CFLAGS  := -DTARGET_SDL2
+  PLATFORM_LDFLAGS := -lm -lpthread -lasound -no-pie
+endif
 ifeq ($(TARGET_WEB),1)
   PLATFORM_CFLAGS  := -DTARGET_WEB
   PLATFORM_LDFLAGS := -lm -no-pie -s TOTAL_MEMORY=20MB -g4 --source-map-base http://localhost:8080/ -s "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']"
@@ -499,6 +508,15 @@ ifeq ($(ENABLE_OPENGL),1)
   ifeq ($(TARGET_LINUX),1)
     GFX_CFLAGS  += $(shell sdl2-config --cflags)
     GFX_LDFLAGS += -lGL $(shell sdl2-config --libs) -lX11 -lXrandr
+  endif
+  ifeq ($(TARGET_SDL2),1)
+    # SDL2 can use either GL or GLES2
+    GFX_CFLAGS  += -DUSE_SDL=2
+    ifeq ($(USE_GLES),1)
+      GFX_LDFLAGS += -lGLESv2 -lSDL2 -DUSE_GLES
+    else
+      GFX_LDFLAGS += -lGL -lSDL2
+    endif
   endif
   ifeq ($(TARGET_WEB),1)
     GFX_CFLAGS  += -s USE_SDL=2

--- a/Makefile
+++ b/Makefile
@@ -487,8 +487,8 @@ ifeq ($(TARGET_LINUX),1)
   PLATFORM_LDFLAGS := -lm -lpthread `pkg-config --libs libusb-1.0` -lasound -lpulse -no-pie
 endif
 ifeq ($(TARGET_SDL2),1)
-  PLATFORM_CFLAGS  := -DTARGET_SDL2
-  PLATFORM_LDFLAGS := -lm -lpthread -no-pie
+  PLATFORM_CFLAGS  := -DTARGET_SDL2 `sdl2-config --cflags`
+  PLATFORM_LDFLAGS := -lm -lpthread -no-pie `sdl2-config --libs`
 endif
 ifeq ($(TARGET_WEB),1)
   PLATFORM_CFLAGS  := -DTARGET_WEB

--- a/src/pc/audio/audio_alsa.c
+++ b/src/pc/audio/audio_alsa.c
@@ -1,6 +1,6 @@
 #include "../compat.h"
 
-#if (defined(__linux__) || defined(__BSD__)) && !defined(TARGET_WEB)
+#if (defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)) && !defined(TARGET_WEB)
 /*
     Simple sound playback using ALSA API and libasound.
     Dependencies: libasound, alsa

--- a/src/pc/audio/audio_alsa.c
+++ b/src/pc/audio/audio_alsa.c
@@ -1,6 +1,6 @@
 #include "../compat.h"
 
-#if (defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)) && !defined(TARGET_WEB)
+#if (defined(__linux__) || defined(__BSD__)) && !defined(TARGET_WEB) && !defined(TARGET_SDL2)
 /*
     Simple sound playback using ALSA API and libasound.
     Dependencies: libasound, alsa

--- a/src/pc/audio/audio_alsa.h
+++ b/src/pc/audio/audio_alsa.h
@@ -3,7 +3,7 @@
 
 #include "../compat.h"
 
-#if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
+#if (defined(__linux__) || defined(__BSD__)) && !defined(TARGET_SDL2)
 extern struct AudioAPI audio_alsa;
 #define HAVE_ALSA 1
 #else

--- a/src/pc/audio/audio_alsa.h
+++ b/src/pc/audio/audio_alsa.h
@@ -3,7 +3,7 @@
 
 #include "../compat.h"
 
-#if defined(__linux__) || defined(__BSD__)
+#if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
 extern struct AudioAPI audio_alsa;
 #define HAVE_ALSA 1
 #else

--- a/src/pc/audio/audio_pulse.c
+++ b/src/pc/audio/audio_pulse.c
@@ -1,6 +1,6 @@
 #include "../compat.h"
 
-#if defined(__linux__) || defined(__BSD__)
+#if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
 
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/pc/audio/audio_pulse.c
+++ b/src/pc/audio/audio_pulse.c
@@ -1,6 +1,6 @@
 #include "../compat.h"
 
-#if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
+#if (defined(__linux__) || defined(__BSD__)) && !defined(TARGET_SDL2)
 
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/pc/audio/audio_pulse.h
+++ b/src/pc/audio/audio_pulse.h
@@ -3,7 +3,7 @@
 
 #include "../compat.h"
 
-#if defined(__linux__) || defined(__BSD__)
+#if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
 extern struct AudioAPI audio_pulse;
 #define HAVE_PULSE_AUDIO 1
 #else

--- a/src/pc/audio/audio_pulse.h
+++ b/src/pc/audio/audio_pulse.h
@@ -3,7 +3,7 @@
 
 #include "../compat.h"
 
-#if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
+#if (defined(__linux__) || defined(__BSD__)) && !defined(TARGET_SDL2)
 extern struct AudioAPI audio_pulse;
 #define HAVE_PULSE_AUDIO 1
 #else

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -12,7 +12,7 @@
 #include "controller_sdl.h"
 #endif
 
-#if defined __linux__ && !defined(TARGET_SDL2)
+#if defined (__linux__) && !defined(TARGET_SDL2)
 #include "controller_wup.h"
 #endif
 
@@ -23,7 +23,7 @@ static struct ControllerAPI *controller_implementations[] = {
 #else
     &controller_sdl,
 #endif
-#if defined __linux__ && !defined(TARGET_SDL2) 
+#if defined (__linux__) && !defined(TARGET_SDL2) 
     &controller_wup,
 #endif
     &controller_keyboard,

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -12,7 +12,7 @@
 #include "controller_sdl.h"
 #endif
 
-#ifdef __linux__
+#if defined __linux__ && !defined(TARGET_SDL2)
 #include "controller_wup.h"
 #endif
 
@@ -23,7 +23,7 @@ static struct ControllerAPI *controller_implementations[] = {
 #else
     &controller_sdl,
 #endif
-#ifdef __linux__
+#if defined __linux__ && !defined(TARGET_SDL2) 
     &controller_wup,
 #endif
     &controller_keyboard,

--- a/src/pc/controller/controller_wup.c
+++ b/src/pc/controller/controller_wup.c
@@ -1,4 +1,4 @@
-#ifdef __linux__
+#if defined __linux__ && !defined(TARGET_SDL2)
 
 #include <stdbool.h>
 #include <pthread.h>

--- a/src/pc/controller/controller_wup.c
+++ b/src/pc/controller/controller_wup.c
@@ -1,4 +1,4 @@
-#if defined __linux__ && !defined(TARGET_SDL2)
+#if defined (__linux__) && !defined(TARGET_SDL2)
 
 #include <stdbool.h>
 #include <pthread.h>

--- a/src/pc/controller/controller_wup.h
+++ b/src/pc/controller/controller_wup.h
@@ -1,7 +1,7 @@
 #ifndef CONTROLLER_WUP_H
 #define CONTROLLER_WUP_H
 
-#ifdef __linux__
+#if defined __linux__ && !defined(TARGET_SDL2)
 
 #include "controller_api.h"
 

--- a/src/pc/controller/controller_wup.h
+++ b/src/pc/controller/controller_wup.h
@@ -1,7 +1,7 @@
 #ifndef CONTROLLER_WUP_H
 #define CONTROLLER_WUP_H
 
-#if defined __linux__ && !defined(TARGET_SDL2)
+#if defined (__linux__) && !defined(TARGET_SDL2)
 
 #include "controller_api.h"
 

--- a/src/pc/controller/wup.c
+++ b/src/pc/controller/wup.c
@@ -1,4 +1,4 @@
-#if !defined(__MINGW32__) && !defined(__BSD__) && !defined(TARGET_WEB)
+#if !defined(__MINGW32__) && !defined(__BSD__) && !defined(TARGET_WEB) && !defined(TARGET_SDL2)
 // See LICENSE for license
 
 #define _XOPEN_SOURCE 600

--- a/src/pc/gfx/gfx_glx.c
+++ b/src/pc/gfx/gfx_glx.c
@@ -1,6 +1,6 @@
 #include "../compat.h"
 
-#if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
+#if (defined(__linux__) || defined(__BSD__)) && !defined(TARGET_SDL2)
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/pc/gfx/gfx_glx.c
+++ b/src/pc/gfx/gfx_glx.c
@@ -1,6 +1,6 @@
 #include "../compat.h"
 
-#if defined(__linux__) || defined(__BSD__)
+#if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -175,7 +175,11 @@ static struct ShaderProgram *gfx_opengl_create_and_load_new_shader(uint32_t shad
     size_t num_floats = 4;
 
     // Vertex shader
+#ifdef USE_GLES
+    append_line(vs_buf, &vs_len, "#version 100");
+#else
     append_line(vs_buf, &vs_len, "#version 110");
+#endif
     append_line(vs_buf, &vs_len, "attribute vec4 aVtxPos;");
     if (cc_features.used_textures[0] || cc_features.used_textures[1]) {
         append_line(vs_buf, &vs_len, "attribute vec2 aTexCoord;");

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -1,6 +1,6 @@
 #include "../compat.h"
 
-#if !defined(__linux__) && !defined(__BSD__) && defined(ENABLE_OPENGL) || defined(TARGET_SDL2)
+#if (!defined(__linux__) && !defined(__BSD__) && defined(ENABLE_OPENGL)) || defined(TARGET_SDL2)
 
 #ifdef __MINGW32__
 #define FOR_WINDOWS 1

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -166,7 +166,7 @@ void main_func(void) {
     wm_api = &gfx_dxgi_api;
 #elif defined(ENABLE_OPENGL)
     rendering_api = &gfx_opengl_api;
-    #if defined(__linux__) || defined(__BSD__)
+    #if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
         wm_api = &gfx_glx;
     #else
         wm_api = &gfx_sdl;
@@ -194,6 +194,11 @@ void main_func(void) {
 #if HAVE_ALSA
     if (audio_api == NULL && audio_alsa.init()) {
         audio_api = &audio_alsa;
+    }
+#endif
+#ifdef TARGET_SDL2
+    if (audio_api == NULL && audio_sdl.init()) {
+        audio_api = &audio_sdl;
     }
 #endif
 #ifdef TARGET_WEB

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -166,7 +166,7 @@ void main_func(void) {
     wm_api = &gfx_dxgi_api;
 #elif defined(ENABLE_OPENGL)
     rendering_api = &gfx_opengl_api;
-    #if defined(__linux__) && !defined(TARGET_SDL2) || defined(__BSD__)
+    #if (defined(__linux__) || defined(__BSD__)) && !defined(TARGET_SDL2) 
         wm_api = &gfx_glx;
     #else
         wm_api = &gfx_sdl;

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -196,12 +196,7 @@ void main_func(void) {
         audio_api = &audio_alsa;
     }
 #endif
-#ifdef TARGET_SDL2
-    if (audio_api == NULL && audio_sdl.init()) {
-        audio_api = &audio_sdl;
-    }
-#endif
-#ifdef TARGET_WEB
+#if defined(TARGET_SDL2) || defined(TARGET_WEB)
     if (audio_api == NULL && audio_sdl.init()) {
         audio_api = &audio_sdl;
     }


### PR DESCRIPTION
This adds an new target called TARGET_SDL2, adds quit via ALT+F4 which is very useful to exit the game when it's running without a window manager (for example, when running the game without X11, directly on a low-latency KMS/DRM enviroment), and also hides the mouse cursor when in fullscreen mode, which is what SDL2 games/ports usually do.