### PR TITLE
Fix shaders when compiling TARGET_WEB

### DIFF
--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -175,7 +175,11 @@ static struct ShaderProgram *gfx_opengl_create_and_load_new_shader(uint32_t shad
     size_t num_floats = 4;
 
     // Vertex shader
+    #ifdef TARGET_WEB
+    append_line(vs_buf, &vs_len, "#version 100");
+    #else
     append_line(vs_buf, &vs_len, "#version 110");
+    #endif
     append_line(vs_buf, &vs_len, "attribute vec4 aVtxPos;");
     if (cc_features.used_textures[0] || cc_features.used_textures[1]) {
         append_line(vs_buf, &vs_len, "attribute vec2 aTexCoord;");
@@ -206,8 +210,12 @@ static struct ShaderProgram *gfx_opengl_create_and_load_new_shader(uint32_t shad
     append_line(vs_buf, &vs_len, "}");
 
     // Fragment shader
+    #ifdef TARGET_WEB
+    append_line(fs_buf, &fs_len, "#version 100");
+    append_line(fs_buf, &fs_len, "precision mediump float;");
+    #else
     append_line(fs_buf, &fs_len, "#version 110");
-    //append_line(fs_buf, &fs_len, "precision mediump float;");
+    #endif
     if (cc_features.used_textures[0] || cc_features.used_textures[1]) {
         append_line(fs_buf, &fs_len, "varying vec2 vTexCoord;");
     }


### PR DESCRIPTION
Compilation succeeds with `emsdk 1.39.5`, but it fails during runtime with the following error:

`sm64.us.html:1246 ERROR: 0:1: '110' : client/version number not supported`