### PR TITLE
Support for N64 controllers

### DIFF
--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -45,6 +45,7 @@ unsigned int configKeyStickDown  = 0x1F;
 unsigned int configKeyStickLeft  = 0x1E;
 unsigned int configKeyStickRight = 0x20;
 // Deadzone value used for SDL and XInput (and WUP?) controllers
+// this number is the minimum magnitude out of (2 ** 15)
 unsigned int configDeadZone      = 4960;
 
 

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -44,6 +44,8 @@ unsigned int configKeyStickUp    = 0x11;
 unsigned int configKeyStickDown  = 0x1F;
 unsigned int configKeyStickLeft  = 0x1E;
 unsigned int configKeyStickRight = 0x20;
+// Deadzone value used for SDL and XInput (and WUP?) controllers
+unsigned int configDeadZone      = 4960;
 
 
 static const struct ConfigOption options[] = {
@@ -61,6 +63,7 @@ static const struct ConfigOption options[] = {
     {.name = "key_stickdown",  .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickDown},
     {.name = "key_stickleft",  .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickLeft},
     {.name = "key_stickright", .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickRight},
+    {.name = "joystick_deadzone", .type = CONFIG_TYPE_UINT, .uintValue = &configDeadZone},
 };
 
 // Reads an entire line from a file (excluding the newline character) and returns an allocated string

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -15,6 +15,7 @@ extern unsigned int configKeyStickUp;
 extern unsigned int configKeyStickDown;
 extern unsigned int configKeyStickLeft;
 extern unsigned int configKeyStickRight;
+extern unsigned int configDeadZone;
 
 void configfile_load(const char *filename);
 void configfile_save(const char *filename);

--- a/src/pc/controller/controller_api.h
+++ b/src/pc/controller/controller_api.h
@@ -2,6 +2,7 @@
 #define CONTROLLER_API
 
 #include <ultra64.h>
+#include <stdio.h>
 
 struct ControllerAPI {
     void (*init)(void);

--- a/src/pc/controller/controller_api.h
+++ b/src/pc/controller/controller_api.h
@@ -2,7 +2,6 @@
 #define CONTROLLER_API
 
 #include <ultra64.h>
-#include <stdio.h>
 
 struct ControllerAPI {
     void (*init)(void);

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -47,7 +47,7 @@ s32 osContStartReadData(UNUSED OSMesgQueue *mesg) {
 }
 
 
-#define DEBUG_PAD_INPUTS 0
+#define DEBUG_PAD_INPUTS 1
 #if DEBUG_PAD_INPUTS
 OSContPad prev_pad;
 void print_pad_inputs(OSContPad *pad) {

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -33,7 +33,7 @@ static struct ControllerAPI *controller_implementations[] = {
 s32 osContInit(UNUSED OSMesgQueue *mq, u8 *controllerBits, UNUSED OSContStatus *status) {
     size_t num_controller_impls = sizeof(controller_implementations) / sizeof(struct ControllerAPI *);
     printf("Initialize controllers\n");
-    printf("num_controller_impls = %d\n", num_controller_impls);
+    printf("num_controller_impls = %ld\n", num_controller_impls);
 
     for (size_t i = 0; i < num_controller_impls; i++) {
         controller_implementations[i]->init();
@@ -46,6 +46,28 @@ s32 osContStartReadData(UNUSED OSMesgQueue *mesg) {
     return 0;
 }
 
+
+#define DEBUG_PAD_INPUTS 0
+#if DEBUG_PAD_INPUTS
+OSContPad prev_pad;
+void print_pad_inputs(OSContPad *pad) {
+    // Remember the latest controller pad inputs and print new inputs
+    // whenever there is a change.
+    if (prev_pad.button != pad->button ||
+        prev_pad.stick_x != pad->stick_x ||
+        prev_pad.stick_y != pad->stick_y ||
+        prev_pad.errnum != pad->errnum)
+    {
+        // Write controller information to stdout
+        printf("Pad: stick_x=%d stick_y=%d button=%d errnum=%d\n",
+                pad->stick_x, pad->stick_y, pad->button, pad->errnum);
+        prev_pad = *pad;
+    }
+}
+#endif
+
+
+
 void osContGetReadData(OSContPad *pad) {
     pad->button = 0;
     pad->stick_x = 0;
@@ -57,4 +79,7 @@ void osContGetReadData(OSContPad *pad) {
     for (size_t i = 0; i < num_controller_impls; i++) {
         controller_implementations[i]->read(pad);
     }
+#if DEBUG_PAD_INPUTS
+        print_pad_inputs(pad);
+#endif
 }

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -1,4 +1,5 @@
 #include "macros.h"
+#include <stdio.h>
 
 #include "lib/src/libultra_internal.h"
 #include "lib/src/osContInternal.h"
@@ -30,7 +31,11 @@ static struct ControllerAPI *controller_implementations[] = {
 };
 
 s32 osContInit(UNUSED OSMesgQueue *mq, u8 *controllerBits, UNUSED OSContStatus *status) {
-    for (size_t i = 0; i < sizeof(controller_implementations) / sizeof(struct ControllerAPI *); i++) {
+    size_t num_controller_impls = sizeof(controller_implementations) / sizeof(struct ControllerAPI *);
+    printf("Initialize controllers\n");
+    printf("num_controller_impls = %d\n", num_controller_impls);
+
+    for (size_t i = 0; i < num_controller_impls; i++) {
         controller_implementations[i]->init();
     }
     *controllerBits = 1;
@@ -47,7 +52,9 @@ void osContGetReadData(OSContPad *pad) {
     pad->stick_y = 0;
     pad->errnum = 0;
 
-    for (size_t i = 0; i < sizeof(controller_implementations) / sizeof(struct ControllerAPI *); i++) {
+    size_t num_controller_impls = sizeof(controller_implementations) / sizeof(struct ControllerAPI *);
+
+    for (size_t i = 0; i < num_controller_impls; i++) {
         controller_implementations[i]->read(pad);
     }
 }

--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -17,29 +17,13 @@ static bool init_ok;
 static SDL_GameController *sdl_cntrl;
 
 static void controller_sdl_init(void) {
+    printf("Initializing SDL Controller\n");
     if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
         fprintf(stderr, "SDL init error: %s\n", SDL_GetError());
         return;
     }
 
     init_ok = true;
-}
-
-static bool needs_controller_input_update = true;
-
-
-OSContPad prev_pad;
-void sdl_controller_printf(OSContPad *pad) {
-    if (prev_pad.button != pad->button ||
-        prev_pad.stick_x != pad->stick_x ||
-        prev_pad.stick_y != pad->stick_y ||
-        prev_pad.errnum != pad->errnum)
-    {
-        // Write controller information to stdout
-        printf("SDL pad: stick_x=%d stick_y=%d button=%d errnum=%d\n",
-                pad->stick_x, pad->stick_y, pad->button, pad->errnum);
-    }
-    prev_pad = *pad;
 }
 
 static void controller_sdl_read(OSContPad *pad) {
@@ -53,19 +37,11 @@ static void controller_sdl_read(OSContPad *pad) {
         printf("Close SDL Game Controller: %p\n", sdl_cntrl);
         SDL_GameControllerClose(sdl_cntrl);
         sdl_cntrl = NULL;
-        needs_controller_input_update = true;
     }
     if (sdl_cntrl == NULL) {
         int num_joysticks = SDL_NumJoysticks();
-        if (needs_controller_input_update){
-            printf("Open SDL Game Controller\n");
-            printf("num_joysticks = %d\n", num_joysticks);
-        }
         for (int i = 0; i < SDL_NumJoysticks(); i++) {
             const char* ctrl_name = SDL_GameControllerNameForIndex(i);
-            if (needs_controller_input_update){
-                printf("Checking SDL Game Controller %d: %s\n", i, ctrl_name);
-            }
             if (SDL_IsGameController(i)) {
                 sdl_cntrl = SDL_GameControllerOpen(i);
                 printf("Found SDL Game Controller = %p\n", sdl_cntrl);
@@ -74,11 +50,7 @@ static void controller_sdl_read(OSContPad *pad) {
                 }
             }
         }
-        needs_controller_input_update = false;
         if (sdl_cntrl == NULL) {
-            if (needs_controller_input_update){
-                printf("No SDL Game Controller detected\n");
-            }
             return;
         }
     }
@@ -126,7 +98,6 @@ static void controller_sdl_read(OSContPad *pad) {
         pad->stick_x = leftx / 409;
         pad->stick_y = -lefty / 409;
     }
-    sdl_controller_printf(pad);
 }
 
 struct ControllerAPI controller_sdl = {

--- a/src/pc/controller/controller_wup.c
+++ b/src/pc/controller/controller_wup.c
@@ -9,12 +9,18 @@
 #include "controller_api.h"
 
 void *wup_start(void *a);
-bool wup_get_controller_input(uint16_t *buttons, uint8_t axis[6]);
+bool wup_get_controller_input(uint16_t *buttons, uint8_t axis[6], bool *do_saturate);
 
 static int8_t saturate(int v) {
     // Is this supposed to map between -80 and 80?
     v = v * 3 / 2;
     return v < -128 ? -128 : v > 127 ? 127 : v;
+}
+
+static int8_t saturate2(int v) {
+    // Is this supposed to map between -80 and 80?
+    //v = v * 11 / 10;
+    return v < -80 ? -80 : v > 80 ? 80 : v;
 }
 
 static void controller_wup_init(void) {
@@ -27,7 +33,10 @@ static void controller_wup_init(void) {
 static void controller_wup_read(OSContPad *pad) {
     uint16_t buttons;
     uint8_t axis[6];
-    if (wup_get_controller_input(&buttons, axis)) {
+    bool do_saturate;
+    int8_t stick_x;
+    int8_t stick_y;
+    if (wup_get_controller_input(&buttons, axis, &do_saturate)) {
         if (buttons & 0x0001) pad->button |= START_BUTTON;
         if (buttons & 0x0008) pad->button |= Z_TRIG;
         if (buttons & 0x0004) pad->button |= R_TRIG;
@@ -38,8 +47,16 @@ static void controller_wup_read(OSContPad *pad) {
         if (axis[2] > 0xC0) pad->button |= R_CBUTTONS;
         if (axis[3] < 0x40) pad->button |= D_CBUTTONS;
         if (axis[3] > 0xC0) pad->button |= U_CBUTTONS;
-        int8_t stick_x = saturate(axis[0] - 128 - 0);
-        int8_t stick_y = saturate(axis[1] - 128 - 0);
+        if (do_saturate) {
+            stick_x = saturate(axis[0] - 128 - 0);
+            stick_y = saturate(axis[1] - 128 - 0);
+        }
+        else {
+            stick_x = saturate2(axis[0] - 128 - 0);
+            stick_y = saturate2(axis[1] - 128 - 0);
+            /*stick_x = axis[0] - 128;*/
+            /*stick_y = axis[1] - 128;*/
+        }
         if (stick_x != 0 || stick_y != 0) {
             pad->stick_x = stick_x;
             pad->stick_y = stick_y;

--- a/src/pc/controller/controller_wup.c
+++ b/src/pc/controller/controller_wup.c
@@ -12,37 +12,22 @@ void *wup_start(void *a);
 bool wup_get_controller_input(uint16_t *buttons, uint8_t axis[6]);
 
 static int8_t saturate(int v) {
+    // Is this supposed to map between -80 and 80?
     v = v * 3 / 2;
     return v < -128 ? -128 : v > 127 ? 127 : v;
 }
 
 static void controller_wup_init(void) {
-    printf("Init WUP Controller\n");
+    printf("Initializing WUP Controller\n");
     pthread_t pid;
     pthread_create(&pid, NULL, wup_start, NULL);
 }
 
 
-OSContPad prev_pad;
-void wup_controller_printf(OSContPad *pad) {
-    if (prev_pad.button != pad->button ||
-        prev_pad.stick_x != pad->stick_x ||
-        prev_pad.stick_y != pad->stick_y ||
-        prev_pad.errnum != pad->errnum)
-    {
-        // Write controller information to stdout
-        printf("WUP pad: stick_x=%d stick_y=%d button=%d errnum=%d\n",
-                pad->stick_x, pad->stick_y, pad->button, pad->errnum);
-    }
-    prev_pad = *pad;
-}
-
 static void controller_wup_read(OSContPad *pad) {
     uint16_t buttons;
     uint8_t axis[6];
     if (wup_get_controller_input(&buttons, axis)) {
-        printf("WUP buttons=%d axis=%d %d %d %d %d %d \n", buttons,
-                axis[0], axis[1], axis[2], axis[3], axis[4], axis[5]);
         if (buttons & 0x0001) pad->button |= START_BUTTON;
         if (buttons & 0x0008) pad->button |= Z_TRIG;
         if (buttons & 0x0004) pad->button |= R_TRIG;
@@ -60,7 +45,6 @@ static void controller_wup_read(OSContPad *pad) {
             pad->stick_y = stick_y;
         }
     }
-    wup_controller_printf(pad);
 }
 
 struct ControllerAPI controller_wup = {

--- a/src/pc/controller/controller_wup.c
+++ b/src/pc/controller/controller_wup.c
@@ -17,12 +17,6 @@ static int8_t saturate(int v) {
     return v < -128 ? -128 : v > 127 ? 127 : v;
 }
 
-static int8_t saturate2(int v) {
-    // Is this supposed to map between -80 and 80?
-    //v = v * 11 / 10;
-    return v < -80 ? -80 : v > 80 ? 80 : v;
-}
-
 static void controller_wup_init(void) {
     printf("Initializing WUP Controller\n");
     pthread_t pid;
@@ -34,9 +28,9 @@ static void controller_wup_read(OSContPad *pad) {
     uint16_t buttons;
     uint8_t axis[6];
     bool do_saturate;
-    int8_t stick_x;
-    int8_t stick_y;
     if (wup_get_controller_input(&buttons, axis, &do_saturate)) {
+        int8_t stick_x;
+        int8_t stick_y;
         if (buttons & 0x0001) pad->button |= START_BUTTON;
         if (buttons & 0x0008) pad->button |= Z_TRIG;
         if (buttons & 0x0004) pad->button |= R_TRIG;
@@ -52,10 +46,9 @@ static void controller_wup_read(OSContPad *pad) {
             stick_y = saturate(axis[1] - 128 - 0);
         }
         else {
-            stick_x = saturate2(axis[0] - 128 - 0);
-            stick_y = saturate2(axis[1] - 128 - 0);
-            /*stick_x = axis[0] - 128;*/
-            /*stick_y = axis[1] - 128;*/
+            // Already in the right range (128-80, 128+80) in this case.
+            stick_x = axis[0] - 128;
+            stick_y = axis[1] - 128;
         }
         if (stick_x != 0 || stick_y != 0) {
             pad->stick_x = stick_x;

--- a/src/pc/controller/controller_wup.c
+++ b/src/pc/controller/controller_wup.c
@@ -18,7 +18,7 @@ static int8_t saturate(int v) {
 }
 
 static void controller_wup_init(void) {
-    printf("Initializing WUP Controller\n");
+    printf("Initializing WUP Controllers\n");
     pthread_t pid;
     pthread_create(&pid, NULL, wup_start, NULL);
 }

--- a/src/pc/controller/controller_wup.c
+++ b/src/pc/controller/controller_wup.c
@@ -2,6 +2,7 @@
 
 #include <stdbool.h>
 #include <pthread.h>
+#include <stdio.h>
 
 #include <ultra64.h>
 
@@ -16,14 +17,32 @@ static int8_t saturate(int v) {
 }
 
 static void controller_wup_init(void) {
+    printf("Init WUP Controller\n");
     pthread_t pid;
     pthread_create(&pid, NULL, wup_start, NULL);
+}
+
+
+OSContPad prev_pad;
+void wup_controller_printf(OSContPad *pad) {
+    if (prev_pad.button != pad->button ||
+        prev_pad.stick_x != pad->stick_x ||
+        prev_pad.stick_y != pad->stick_y ||
+        prev_pad.errnum != pad->errnum)
+    {
+        // Write controller information to stdout
+        printf("WUP pad: stick_x=%d stick_y=%d button=%d errnum=%d\n",
+                pad->stick_x, pad->stick_y, pad->button, pad->errnum);
+    }
+    prev_pad = *pad;
 }
 
 static void controller_wup_read(OSContPad *pad) {
     uint16_t buttons;
     uint8_t axis[6];
     if (wup_get_controller_input(&buttons, axis)) {
+        printf("WUP buttons=%d axis=%d %d %d %d %d %d \n", buttons,
+                axis[0], axis[1], axis[2], axis[3], axis[4], axis[5]);
         if (buttons & 0x0001) pad->button |= START_BUTTON;
         if (buttons & 0x0008) pad->button |= Z_TRIG;
         if (buttons & 0x0004) pad->button |= R_TRIG;
@@ -41,6 +60,7 @@ static void controller_wup_read(OSContPad *pad) {
             pad->stick_y = stick_y;
         }
     }
+    wup_controller_printf(pad);
 }
 
 struct ControllerAPI controller_wup = {

--- a/src/pc/controller/controller_xinput.c
+++ b/src/pc/controller/controller_xinput.c
@@ -7,7 +7,9 @@
 
 #include "controller_api.h"
 
-#define DEADZONE 4960
+#include "../configfile.h"
+
+// #define DEADZONE 4960
 
 static void xinput_init(void) {
 }
@@ -32,7 +34,7 @@ static void xinput_read(OSContPad *pad) {
             if (gp->sThumbRY > 0x4000) pad->button |= U_CBUTTONS;
 
             uint32_t magnitude_sq = (uint32_t)(gp->sThumbLX * gp->sThumbLX) + (uint32_t)(gp->sThumbLY * gp->sThumbLY);
-            if (magnitude_sq > (uint32_t)(DEADZONE * DEADZONE)) {
+            if (magnitude_sq > (uint32_t)(configDeadZone * configDeadZone)) {
                 // Game expects stick coordinates within -80..80
                 // 32768 / 409 = ~80
                 pad->stick_x = gp->sThumbLX / 409;

--- a/src/pc/controller/update_wup_logic.py
+++ b/src/pc/controller/update_wup_logic.py
@@ -1,0 +1,236 @@
+import math
+import textwrap
+import sympy as sym
+from collections import namedtuple
+
+# configDeadZoneFrac = 4960 / (2 ** 15)
+
+PayloadButon = namedtuple('PayloadButon', ['index', 'bitv'])
+AxisPoints = namedtuple('PayloadButon', ['index', 'left_extreme', 'left_mid', 'left_zero', 'right_zero', 'right_mid', 'right_extreme'])
+
+# Mapping from button names to the payload index and associated bit value.
+payload_buttons = {}
+payload_buttons['Z'] = PayloadButon(0, 64)
+payload_buttons['R'] = PayloadButon(0, 32)
+payload_buttons['L'] = PayloadButon(0, 16)
+payload_buttons['A'] = PayloadButon(0, 4)
+payload_buttons['B'] = PayloadButon(0, 2)
+payload_buttons['START'] = PayloadButon(1, 2)
+
+# Mapping from button names to target bits to their expected bits in port->buttons
+adapter_buttons = {}
+adapter_buttons['START'] = 0x0001
+adapter_buttons['Z'] = 0x0008
+adapter_buttons['R'] = 0x0004
+adapter_buttons['A'] = 0x0100
+adapter_buttons['B'] = 0x0200
+adapter_buttons['L'] = 0x1000
+
+# Mapping from axis directions to the payload index, neutral, and extreme value.
+payload_axis = {}
+
+"""
+From the manual
+The Control Stick's coordinate positions stick_x and stick_y
+are signed characters with the range of -128 ~ 127.
+However, for the actual program we recommend using values
+within the ranges shown below:
+
+Left/right X axis   +/- 61
+Up/down Y axis      +/- 63
+X axis incline      +/- 45
+Y axis incline      +/- 47
+"""
+
+
+# The tuple will mean: payload_idx, left extreme, left mid, left zero, right zero, right mid, right extreme.
+# Idealized
+payload_axis['STICK_LEFT_RIGHT']  = AxisPoints(3, 128 - 63, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 63)
+payload_axis['STICK_UP_DOWN']     = AxisPoints(4, 128 - 61, 128 - 45, 128 - 31, 128 + 31, 128 + 45, 128 + 61)
+# Bumping these values to try and make things "feel right"?
+# payload_axis['STICK_LEFT_RIGHT']  = AxisPoints(3, 128 - 103, 128 - 57, 128 - 31, 128 + 31, 128 + 57, 128 + 103)
+# payload_axis['STICK_UP_DOWN']     = AxisPoints(4, 128 - 101, 128 - 57, 128 - 31, 128 + 31, 128 + 57, 128 + 101)
+
+# Mapping from the button direction to its associated index in port->axis, neutral value, and extreme value.
+adapter_axis = {}
+
+# Mapping from the button direction to its associated index in port->axis, left-extreme, left-ramp, left-min, right-min, right-ramp, right-extreme
+# Mapping from the button direction to its associated index in port->axis, up-extreme, up-ramp, up-min, down-min, down-ramp, down-extreme
+# Saturation values should be -80 to 80
+adapter_axis['STICK_LEFT_RIGHT']  = AxisPoints(0, 128 - 80, 128 - 40, 128 + 0, 128 + 0, 128 + 40, 128 + 80)
+adapter_axis['STICK_UP_DOWN']     = AxisPoints(1, 128 + 80, 128 + 40, 128 + 0, 128 - 0, 128 - 40, 128 - 80)
+
+
+SYMBOLIC = 1
+if SYMBOLIC:
+    LR_src1, LR_src2, LR_src3, LR_src4, LR_src5, LR_src6 = sym.symbols('LR_src1, LR_src2, LR_src3, LR_src4, LR_src5, LR_src6')
+    UD_src1, UD_src2, UD_src3, UD_src4, UD_src5, UD_src6 = sym.symbols('UD_src1, UD_src2, UD_src3, UD_src4, UD_src5, UD_src6')
+    payload_axis['STICK_LEFT_RIGHT']  = AxisPoints(3, LR_src1, LR_src2, LR_src3, LR_src4, LR_src5, LR_src6)
+    payload_axis['STICK_UP_DOWN']     = AxisPoints(4, UD_src1, UD_src2, UD_src3, UD_src4, UD_src5, UD_src6)
+
+    LR_dst1, LR_dst2, LR_dst3, LR_dst4, LR_dst5, LR_dst6 = sym.symbols('LR_dst1, LR_dst2, LR_dst3, LR_dst4, LR_dst5, LR_dst6')
+    UD_dst1, UD_dst2, UD_dst3, UD_dst4, UD_dst5, UD_dst6 = sym.symbols('UD_dst1, UD_dst2, UD_dst3, UD_dst4, UD_dst5, UD_dst6')
+    adapter_axis['STICK_LEFT_RIGHT']  = AxisPoints(0, LR_dst1, LR_dst2, LR_dst3, LR_dst4, LR_dst5, LR_dst6)
+    adapter_axis['STICK_UP_DOWN']     = AxisPoints(1, UD_dst1, UD_dst2, UD_dst3, UD_dst4, UD_dst5, UD_dst6)
+
+
+# payload_defaults = {
+#     #
+#     LR_src1: 128 - 63,
+#     LR_src2: 128 - 47,
+#     LR_src3: 128 - 31,
+#     LR_src4: 128 + 31,
+#     LR_src5: 128 + 47,
+#     LR_src6: 128 + 63,
+#     #
+#     UD_src1: 128 + 61,
+#     UD_src2: 128 + 45,
+#     UD_src3: 128 + 31,
+#     UD_src4: 128 - 31,
+#     UD_src5: 128 - 45,
+#     UD_src6: 128 - 61,
+# }
+
+
+EVALF = 0
+
+with sym.evaluate(EVALF):
+
+    # I find that 6272 works well for my xbox controller
+    # 4960 is the default.
+    configDeadZone = sym.symbols('configDeadZone')
+
+    src_width = int(2 ** 7)
+    dst_width = int(2 ** 15)
+    configDeadFrac = configDeadZone / dst_width
+    configDeadAdj = src_width * configDeadFrac
+
+    mid = sym.Integer(128)
+    payload_defaults = {
+        #
+        LR_src1: mid - 103,
+        LR_src2: mid - 57,
+        LR_src3: mid - configDeadAdj,
+        LR_src4: mid + configDeadAdj,
+        LR_src5: mid + 57,
+        LR_src6: mid + 103,
+        #
+        UD_src1: mid - 101,
+        UD_src2: mid - 57,
+        UD_src3: mid - configDeadAdj,
+        UD_src4: mid + configDeadAdj,
+        UD_src5: mid + 57,
+        UD_src6: mid + 101,
+    }
+
+    adapter_defaults = {
+        #
+        LR_dst1: mid - 80,
+        LR_dst2: mid - 40,
+        LR_dst3: mid - 0,
+        LR_dst4: mid + 0,
+        LR_dst5: mid + 40,
+        LR_dst6: mid + 80,
+        #
+        UD_dst1: mid + 80,
+        UD_dst2: mid + 40,
+        UD_dst3: mid + 0,
+        UD_dst4: mid - 0,
+        UD_dst5: mid - 40,
+        UD_dst6: mid - 80,
+    }
+
+symbolic_defaults = {
+    **adapter_defaults,
+    **payload_defaults,
+    configDeadZone: 4960,
+}
+
+# The following will generate code to builds the port->buttons data from payload.
+lines = []
+button_parts = []
+for k, (idx, val) in payload_buttons.items():
+    adapt_val = adapter_buttons[k]
+    if val > adapt_val:
+        shift = int(math.log2(val / adapt_val))
+        button_parts.append(f' (uint16_t) (payload[{idx}] & {val:#04x}) >> {shift} |  // map {k} to {adapt_val:#04x} ')
+    else:
+        shift = int(math.log2(adapt_val / val))
+        button_parts.append(f' (uint16_t) (payload[{idx}] & {val:#04x}) << {shift} |  // map {k} to {adapt_val:#04x}')
+lines.append('uint16_t btns = (')
+lines.append('\n'.join(button_parts))
+lines.append(');')
+
+### In progress writing better logic
+### This logic gets us most of the way there, but we do a bit more manual munging after
+
+
+lines.append('\n// Source payload magnitudes to be mapped')
+for k, d in payload_defaults.items():
+    if EVALF:
+        d = d.subs(symbolic_defaults)
+    lines.append(f'float {k} = {d};'.replace('configDeadZone', '((float) configDeadZone)'))
+
+lines.append('\n// Destination adapater magnitudes to map to')
+for k, d in adapter_defaults.items():
+    if EVALF:
+        d = d.subs(symbolic_defaults)
+    lines.append(f'float {k} = {d};'.replace('configDeadZone', '((float) configDeadZone)'))
+
+lines.append('\n// Default to a zero position')
+lines.append(f'uint8_t stick_lr_val = (uint8_t) {adapter_axis["STICK_LEFT_RIGHT"][3]};')
+lines.append(f'uint8_t stick_ud_val = (uint8_t) {adapter_axis["STICK_UP_DOWN"][3]};')
+for key, payload_tup in payload_axis.items():
+    adapt_tup = adapter_axis[key]
+    if adapt_tup is not NotImplemented:
+        idx1, *vals1 = payload_tup
+        idx2, *vals2 = adapt_tup
+        p = sym.symbols('VAL')
+
+        if key in ['STICK_LEFT_RIGHT']:
+            var = 'stick_lr_val'
+        else:
+            var = 'stick_ud_val'
+
+        v1 = vals1[0]
+        v2 = vals2[0]
+        if EVALF:
+            v1 = v1.subs(symbolic_defaults)
+            v2 = v2.subs(symbolic_defaults)
+        raw = f'payload[{idx1}]'
+        lines.append('')
+        lines.append(f'// Handle {key}')
+        lines.append(f'if ( {raw} < {v1} )')
+        lines.append('{')
+        lines.append(f'    {var} = {v2};  // Handle {key} extreme low')
+        lines.append('}')
+        for i in range(len(vals1) - 1):
+            v11 = vals1[i]
+            v12 = vals1[i + 1]
+            v21 = vals2[i]
+            v22 = vals2[i + 1]
+
+            range1 = v12 - v11
+            range2 = v22 - v21
+            el = '' if i == 0 else 'else '
+            r = (((p - v11) / range1) * range2 + v21).evalf()
+            if EVALF:
+                r = r.subs(symbolic_defaults)
+            expr = repr(r).replace('VAL', f'((float) payload[{idx1}])')
+
+            if EVALF:
+                v12 = v12.subs(symbolic_defaults)
+
+            lines.append(f'else if ( {raw} < {v12} )')
+            lines.append('{')
+            lines.append(f'    {var} = (uint8_t) ({expr});  // Handle {key} ramp')
+            lines.append('}')
+        v1 = vals1[-1]
+        v2 = vals2[-1]
+        lines.append('else')
+        lines.append('{')
+        lines.append(f'    {var} = {v2};  // Handle {key} extreme high')
+        lines.append('}')
+
+
+print(textwrap.indent(chr(10).join(lines), '    '))

--- a/src/pc/controller/wup.c
+++ b/src/pc/controller/wup.c
@@ -114,10 +114,13 @@ static unsigned char connected_type(unsigned char status)
    }
 }
 
+
 static void handle_payload(int i, struct ports *port, unsigned char *payload)
 {
    unsigned char status = payload[0];
    unsigned char type = connected_type(status);
+
+   printf("Handle payload\n");
 
    if (type != 0 && !port->connected)
    {
@@ -144,17 +147,207 @@ static void handle_payload(int i, struct ports *port, unsigned char *payload)
 
    uint16_t btns = (uint16_t) payload[1] << 8 | (uint16_t) payload[2];
    port->buttons = btns;
-   //printf("Btns: %04x\n", btns);
+   // printf("Btns: %04x\n", btns);
 
-   //printf("Axis:");
+   // printf("Axis:");
    for (int j = 0; j < 6; j++)
    {
       unsigned char value = payload[j+3];
       port->axis[j] = value;
-      //printf(" %02x", value);
+      // printf(" %02x", value);
    }
-   //puts("");
+   // puts("");
 }
+
+
+
+static void handle_hyperkin_payload(int i, struct ports *port, unsigned char *payload)
+{
+    /*
+     * This function is written to support the original N64 controller
+     * plugged in using a hyperkin adapter. We do this by simply coercing
+     * the payload into an adapter buttons and axis that controller_wup.c will expect
+     */
+
+   unsigned char type = STATE_NORMAL; // hacked
+
+   /*printf("Handle hyperkin payload\n");*/
+
+   if (type != 0 && !port->connected)
+   {
+      //uinput_create(i, port, type);
+       port->type = type;
+       port->connected = true;
+   }
+   else if (type == 0 && port->connected)
+   {
+      //uinput_destroy(i, port);
+       port->connected = false;
+   }
+
+   if (!port->connected)
+      return;
+
+   port->extra_power = 0; // hacked
+
+   if (type != port->type)
+   {
+      fprintf(stderr, "controller on port %d changed controller type???", i+1);
+      port->type = type;
+   }
+
+
+   /*
+   * Hyperkin64 Adapter Notes
+   * NEUTRAL PAYLOAD:
+   pl[0] = 0,  # main buttons
+   pl[1] = 0,  # start button
+   pl[2] = 8,  # d-pad
+   pl[3] = 128,  # stick-lr
+   pl[4] = 127,  # stick-ud
+   pl[5] = 128,  # c-buttons
+   pl[6] = 127,  # c-buttons
+   pl[7] = 0,    # unused
+
+   * Z = payload[0] == 0 -> 64 - 0x40
+   * R = payload[0] == 0 -> 32
+   * L = payload[0] == 0 -> 16
+   * A = payload[0] == 0 -> 4
+   * B = payload[0] == 0 -> 2
+   * start = payload[1] == 0 -> 2
+   * c-right = payload[5] == 128 -> 255
+   * c-left = payload[5] == 128 -> 0
+   * c-up = payload[6] == 127 -> 0
+   * c-down = payload[6] == 255 -> 0
+   * d-up = payload[2] == 8 -> 0
+   * d-down = payload[2] == 8 -> 4
+   * d-left = payload[2] == 8 -> 6
+   * d-right = payload[2] == 8 -> 2
+   * stick = payload[3], payload[4] == neutral: 128, 127
+   * stick-LR-axis = payload[3] == nuetral: 128, left=13, right=243, can go up to 2/245 on hori-minipad, nutral on hori seems to be 102
+   * stick-UD-axis = payload[4] == nuetral: 127, top=12, bot=254, can go from 2 to 254 on hori minipad. Nuetroal on hori is still 127
+
+   # Mapping from button name to payload index and bit value
+   adapter_buttons = {}
+   adapter_axis = {}
+   adapter_buttons['START'] = 0x0001
+   adapter_buttons['Z'] = 0x0008;
+   adapter_buttons['R'] = 0x0004;
+   adapter_buttons['A'] = 0x0100;
+   adapter_buttons['B'] = 0x0200;
+   adapter_buttons['L'] = 0x1000;
+
+   payload_buttons = {}
+   payload_axis = {}
+   payload_buttons['Z'] = (0, 64)
+   payload_buttons['R'] = (0, 32)
+   payload_buttons['L'] = (0, 16)
+   payload_buttons['A'] = (0, 4)
+   payload_buttons['B'] = (0, 2)
+   payload_buttons['START'] = (1, 2)
+
+   payload_axis['C_LEFT'] = (5, 255)
+   payload_axis['C_RIGHT'] = (5, 0)
+   payload_axis['C_UP'] = (6, 0)
+   payload_axis['C_DOWN'] = (6, 255)
+   import math
+   button_parts = []
+   for k, (idx, val) in payload_buttons.items():
+       adapt_val = adapter_buttons[k]
+       if val > adapt_val:
+           shift = int(math.log2(val / adapt_val))
+           button_parts.append(f' (uint16_t) (payload[{idx}] & {val:#04x}) >> {shift} |  // map {k} to {adapt_val:#04x} ')
+       else:
+           shift = int(math.log2(adapt_val / val))
+           button_parts.append(f' (uint16_t) (payload[{idx}] & {val:#04x}) << {shift} |  // map {k} to {adapt_val:#04x}')
+       print(f'payload[{idx}] & {val:016b} -> {adapt_val:016b} - {k}')
+
+
+   # axis index, and value
+   adapter_axis['C_LEFT'] = (2, 0x40);
+   adapter_axis['C_RIGHT'] = (2, 0xC0);
+   adapter_axis['C_DOWN'] = (3, 0x40);
+   adapter_axis['C_UP'] = ??
+   adapter_axis['D_UP'] = ??
+   adapter_axis['STICK_LEFT'] = (0, None);
+   adapter_axis['STICK_UP'] = (1, None):
+   for k (idx, val) in payload_axis.items():
+       pass
+
+   print('uint16_t btns = (')
+   print('\n'.join(button_parts))
+   print(');')
+   */
+
+   uint16_t btns = (
+     (uint16_t) (payload[0] & 0x40) >> 3 |  // map Z to 0x08
+     (uint16_t) (payload[0] & 0x20) >> 3 |  // map R to 0x04
+     (uint16_t) (payload[0] & 0x10) << 8 |  // map L to 0x1000
+     (uint16_t) (payload[0] & 0x04) << 6 |  // map A to 0x100
+     (uint16_t) (payload[0] & 0x02) << 8 |  // map B to 0x200
+     (uint16_t) (payload[1] & 0x02) >> 1    // map START to 0x01
+   );
+
+   port->buttons = btns;
+
+   // The values need to be nudged slightly
+   // Game expects stick coordinates within -80..80
+   // 32768 / 409 = ~80
+   port->axis[2] = payload[5];  // map C-lr to axis 2
+   port->axis[3] = 255 - payload[6];  // map C-ud to axis 3
+
+   // Hack because I'm bad at c-math apparently
+   // We really don't need floats for this, but I just wanna play a run.
+   /*float left = 13;*/
+   /*float right = 243;*/
+   /*float top = 12;*/
+   /*float bot = 254;*/
+   float xcenter = 102;
+   float ycenter = 127;
+   float raw_x = (float) payload[3];
+   float raw_y = (float) payload[4];
+
+   float unit_x = (raw_x - xcenter) / 128; // -1 to 1
+   float unit_y = -(raw_y - ycenter) / 128; // -1 to 1
+   if (unit_x < 0){
+       unit_x /= (xcenter / 128.);
+   }
+   else {
+       unit_x /= (255 - xcenter) / 128.;
+   }
+   if (unit_y < 0){
+       unit_y /= (ycenter / 128.);
+   }
+   else {
+       unit_y /= (255 - ycenter) / 128.;
+   }
+   if (unit_y < 0.2 && unit_y > -0.2){
+       unit_y = 0;
+   }
+   if (unit_x < 0.2 && unit_x > -0.2){
+       unit_x = 0;
+   }
+   uint8_t byte_x = (uint8_t) (unit_x * 80 + 128);
+   uint8_t byte_y = (uint8_t) (unit_y * 80 + 128);
+   printf("Raw_XY %f %f\n", raw_x, raw_y);
+   printf("Unit_XY %f %f\n", unit_x, unit_y);
+   printf("Fudged_XY %d %d\n", byte_x, byte_y);
+   port->axis[0] = byte_x;
+   port->axis[1] = byte_y;
+
+   /*port->axis[0] = (uint8_t) (((int) payload[3]) * 5 / 8);  // map stick-lr to axis - 0        */
+   /*port->axis[1] = (uint8_t) (((int) (255 - payload[4])) * 5 / 8);  // map stick-lr to axis - 1*/
+   // D pad seems unhandled.
+
+   /*for (int j = 0; j < 6; j++)           */
+   /*{                                     */
+   /*   unsigned char value = payload[j+3];*/
+   /*   port->axis[j] = value;             */
+   /*   [>printf(" %02x", value);<]        */
+   /*}                                     */
+   /*puts("");*/
+}
+
 
 static int64_t to_ms(struct timespec* t) {
     return t->tv_sec * 1000 + t->tv_nsec / 1000000;
@@ -169,7 +362,7 @@ static void *adapter_thread(void *data)
 
     int transfer_ret = libusb_interrupt_transfer(a->handle, EP_OUT, payload, sizeof(payload), &bytes_transferred, 0);
 
-    if (transfer_ret != 0) {
+    if (transfer_ret != LIBUSB_SUCCESS) {
         fprintf(stderr, "libusb_interrupt_transfer: %s\n", libusb_error_name(transfer_ret));
         return NULL;
     }
@@ -187,14 +380,31 @@ static void *adapter_thread(void *data)
       int transfer_ret = libusb_interrupt_transfer(a->handle, EP_IN, payload, sizeof(payload), &size, 0);
       //clock_gettime(CLOCK_MONOTONIC, &time_after);
       //printf("Time taken: %d\n", (int)(to_ms(&time_after) - to_ms(&time_before)));
-      if (transfer_ret != 0) {
+      if (transfer_ret != LIBUSB_SUCCESS) {
          fprintf(stderr, "libusb_interrupt_transfer error %d\n", transfer_ret);
          a->quitting = true;
          break;
       }
+      printf("size %d\n", size);
+      for (int i = 0; i < size; i ++ ){
+          printf("pl[%d] = %d, ", i, payload[i]);
+      }
+      printf("\n");
+
+      if (size == 8)
+      {
+          // hack in our special handling for hyperkin n64
+          // no rumble support.
+          for (int i = 0; i < 4; i++)
+          {
+              handle_hyperkin_payload(i, &a->controllers[i], payload);
+          }
+          continue;
+      }
+
       if (size != 37 || payload[0] != 0x21)
          continue;
-      
+
       unsigned char *controller = &payload[1];
 
       unsigned char rumble[5] = { 0x11, 0, 0, 0, 0 };
@@ -252,10 +462,21 @@ static void add_adapter(struct libusb_device *dev)
    }
    a->device = dev;
 
-   if (libusb_open(a->device, &a->handle) != 0)
+   int open_status = libusb_open(a->device, &a->handle);
+   if (open_status != LIBUSB_SUCCESS)
    {
-      fprintf(stderr, "Error opening device 0x%p\n", a->device);
+      fprintf(stderr, "Error %d opening device 0x%p\n", open_status, a->device);
       return;
+   }
+   else {
+      printf("Opened WUP adapter\n");
+      /*unsigned char dev_desc[512] = {0};*/
+      /*int ret = libusb_get_string_descriptor_ascii(&a->handle, 0, dev_desc, sizeof(dev_desc));*/
+      /*if (libusb_error.LIBUSB_SUCCESS == ret){*/
+      /*if (ret == 0){                          */
+      /*    printf("%d\n", ret);                */
+      /*    printf("%s\n", dev_desc);           */
+      /*}                                       */
    }
 
    if (libusb_kernel_driver_active(a->handle, 0) == 1) {
@@ -319,12 +540,20 @@ void *wup_start(UNUSED void *a)
    struct libusb_device **devices;
 
    int count = libusb_get_device_list(NULL, &devices);
+   printf("WUP num devices = %d\n", count);
 
    for (int i = 0; i < count; i++)
    {
       struct libusb_device_descriptor desc;
+
       libusb_get_device_descriptor(devices[i], &desc);
+      printf("Vendor:Device = %04x:%04x\n", desc.idVendor, desc.idProduct);
+
       if (desc.idVendor == 0x057e && desc.idProduct == 0x0337)
+         add_adapter(devices[i]);
+
+      // BDA N64 Hyperkin Adapter
+      if (desc.idVendor == 0x20d6 && desc.idProduct == 0xa710)
          add_adapter(devices[i]);
    }
 
@@ -334,6 +563,7 @@ void *wup_start(UNUSED void *a)
    libusb_hotplug_callback_handle callback;
 
    int hotplug_capability = libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG);
+   printf("hotplug_capability = %d\n", hotplug_capability);
    if (hotplug_capability) {
        int hotplug_ret = libusb_hotplug_register_callback(NULL,
              LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED | LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT,

--- a/src/pc/controller/wup.c
+++ b/src/pc/controller/wup.c
@@ -1,3 +1,15 @@
+/*
+ *
+ clang-format -style=gnu -dump-config > .clang-format
+ clang-format -style=gnu ~/code/sm64-port/src/pc/controller/wup.c
+ clang-format -style=mozilla ~/code/sm64-port/src/pc/controller/wup.c
+ clang-format -style=chromium ~/code/sm64-port/src/pc/controller/wup.c
+
+ clang-format -style=microsoft ~/code/sm64-port/src/pc/controller/wup.c -i
+ clang-format -style=file:$HOME/code/sm64-port/.clang-format ~/code/sm64-port/src/pc/controller/wup.c -i
+
+ */
+
 #if !defined(__MINGW32__) && !defined(__BSD__) && !defined(TARGET_WEB)
 // See LICENSE for license
 
@@ -24,62 +36,54 @@
 
 #include "macros.h"
 
-#if (!defined(LIBUSBX_API_VERSION) || LIBUSBX_API_VERSION < 0x01000102) && (!defined(LIBUSB_API_VERSION) || LIBUSB_API_VERSION < 0x01000102)
+#if (!defined(LIBUSBX_API_VERSION) || LIBUSBX_API_VERSION < 0x01000102)                                \
+    && (!defined(LIBUSB_API_VERSION) || LIBUSB_API_VERSION < 0x01000102)
 #error libusb(x) 1.0.16 or higher is required
 #endif
 
-#define EP_IN  0x81
+#define EP_IN 0x81
 #define EP_OUT 0x02
 
-#define STATE_NORMAL   0x10
+#define STATE_NORMAL 0x10
 #define STATE_WAVEBIRD 0x20
 
 const int BUTTON_OFFSET_VALUES[16] = {
-   BTN_START,
-   BTN_TR2,
-   BTN_TR,
-   BTN_TL,
-   -1,
-   -1,
-   -1,
-   -1,
-   BTN_SOUTH,
-   BTN_WEST,
-   BTN_EAST,
-   BTN_NORTH,
-   BTN_DPAD_LEFT,
-   BTN_DPAD_RIGHT,
-   BTN_DPAD_DOWN,
-   BTN_DPAD_UP,
+    BTN_START,
+    BTN_TR2,
+    BTN_TR,
+    BTN_TL,
+    -1,
+    -1,
+    -1,
+    -1,
+    BTN_SOUTH,
+    BTN_WEST,
+    BTN_EAST,
+    BTN_NORTH,
+    BTN_DPAD_LEFT,
+    BTN_DPAD_RIGHT,
+    BTN_DPAD_DOWN,
+    BTN_DPAD_UP,
 };
 
-const int AXIS_OFFSET_VALUES[6] = {
-   ABS_X,
-   ABS_Y,
-   ABS_RX,
-   ABS_RY,
-   ABS_Z,
-   ABS_RZ
+const int AXIS_OFFSET_VALUES[6] = { ABS_X, ABS_Y, ABS_RX, ABS_RY, ABS_Z, ABS_RZ };
+
+struct ports {
+    bool connected;
+    bool extra_power;
+    unsigned char type;
+    uint16_t buttons;
+    uint8_t axis[6];
 };
 
-struct ports
-{
-   bool connected;
-   bool extra_power;
-   unsigned char type;
-   uint16_t buttons;
-   uint8_t axis[6];
-};
-
-struct adapter
-{
-   volatile bool quitting;
-   struct libusb_device *device;
-   struct libusb_device_handle *handle;
-   pthread_t thread;
-   unsigned char rumble[5];
-   struct ports controllers[4];
-   struct adapter *next;
+struct adapter {
+    volatile bool quitting;
+    struct libusb_device *device;
+    struct libusb_device_handle *handle;
+    pthread_t thread;
+    unsigned char rumble[5];
+    struct ports controllers[4];
+    struct adapter *next;
 };
 
 static bool raw_mode;
@@ -90,9 +94,7 @@ static struct adapter adapters;
 
 static const char *uinput_path;
 
-
-bool wants_saturate = true;  // hack for difference in need for saturation
-
+bool wants_saturate = true; // hack for difference in need for saturation
 
 bool wup_get_controller_input(uint16_t *buttons, uint8_t axis[6], bool *do_saturate) {
 
@@ -109,690 +111,636 @@ bool wup_get_controller_input(uint16_t *buttons, uint8_t axis[6], bool *do_satur
     }
 }
 
-static unsigned char connected_type(unsigned char status)
-{
-   unsigned char type = status & (STATE_NORMAL | STATE_WAVEBIRD);
-   switch (type)
-   {
-      case STATE_NORMAL:
-      case STATE_WAVEBIRD:
-         return type;
-      default:
-         return 0;
-   }
+static unsigned char connected_type(unsigned char status) {
+    unsigned char type = status & (STATE_NORMAL | STATE_WAVEBIRD);
+    switch (type) {
+        case STATE_NORMAL:
+        case STATE_WAVEBIRD:
+            return type;
+        default:
+            return 0;
+    }
 }
 
+static void handle_payload(int i, struct ports *port, unsigned char *payload) {
+    unsigned char status = payload[0];
+    unsigned char type = connected_type(status);
 
-static void handle_payload(int i, struct ports *port, unsigned char *payload)
-{
-   unsigned char status = payload[0];
-   unsigned char type = connected_type(status);
+    wants_saturate = true;
 
-   wants_saturate = true;
+    if (type != 0 && !port->connected) {
+        // uinput_create(i, port, type);
+        port->type = type;
+        port->connected = true;
+    } else if (type == 0 && port->connected) {
+        // uinput_destroy(i, port);
+        port->connected = false;
+    }
 
-   if (type != 0 && !port->connected)
-   {
-      //uinput_create(i, port, type);
-       port->type = type;
-       port->connected = true;
-   }
-   else if (type == 0 && port->connected)
-   {
-      //uinput_destroy(i, port);
-       port->connected = false;
-   }
+    if (!port->connected)
+        return;
 
-   if (!port->connected)
-      return;
+    port->extra_power = ((status & 0x04) != 0);
 
-   port->extra_power = ((status & 0x04) != 0);
+    if (type != port->type) {
+        fprintf(stderr, "controller on port %d changed controller type???", i + 1);
+        port->type = type;
+    }
 
-   if (type != port->type)
-   {
-      fprintf(stderr, "controller on port %d changed controller type???", i+1);
-      port->type = type;
-   }
+    uint16_t btns = (uint16_t) payload[1] << 8 | (uint16_t) payload[2];
+    port->buttons = btns;
+    // printf("Btns: %04x\n", btns);
 
-   uint16_t btns = (uint16_t) payload[1] << 8 | (uint16_t) payload[2];
-   port->buttons = btns;
-   //printf("Btns: %04x\n", btns);
-
-   //printf("Axis:");
-   for (int j = 0; j < 6; j++)
-   {
-      unsigned char value = payload[j+3];
-      port->axis[j] = value;
-      //printf(" %02x", value);
-   }
-   //puts("");
+    // printf("Axis:");
+    for (int j = 0; j < 6; j++) {
+        unsigned char value = payload[j + 3];
+        port->axis[j] = value;
+        // printf(" %02x", value);
+    }
+    // puts("");
 }
 
+static void handle_hyperkin_payload(int i, struct ports *port, unsigned char *payload) {
+    /*"""
+     *
+     *
+      References:
+      https://digitalcommons.calpoly.edu/cgi/viewcontent.cgi?article=1185&context=eesp
+      ipfs.io/ipfs/bafybeighb4imouukdmn4w77i5j72oovprbvkgstujlerlxiryf44zb3iny
+
+      http://ultra64.ca/files/documentation/online-manuals/man/pro-man/pro26/26-02.html#04.1
+           //
+           //http://n64devkit.square7.ch/pro-man/pro26/26-02.htm
+
+      The Control Stick's coordinate positions stick_x and stick_y are signed
+      characters with the range of -128 ~ 127. However, for the actual program we
+      recommend using values within the ranges shown below:
+
+      Left/right X axis   +/- 61
+      Up/down Y axis      +/- 63
+      X axis incline      +/- 45
+      Y axis incline      +/- 47
+
+      +--------------------+-------------------+-------------+------------+
+      | Payload (unsigned) |  Payload (signed) | OSContValue |  Note      |
+      +--------------------+-------------------+-------------+------------+
+      |           127      |             0     |      0      |  Deadzone  |
+      +--------------------+-------------------+-------------+------------+
+      |           100      |           -27     |      0      |  Deadzone  |
+      +--------------------+-------------------+-------------+------------+
+      |            99      |           -28     |      1      |  Minimum   |
+      +--------------------+-------------------+-------------+------------+
+      |            80      |           -47     |     40      |  Incline   |
+      +--------------------+-------------------+-------------+------------+
+      |            64      |           -63     |     80      |  Maximum   |
+      +--------------------+-------------------+-------------+------------+
+      |             0      |          -127     |     80      |  Saturated |
+      +--------------------+-------------------+-------------+------------+
 
 
-static void handle_hyperkin_payload(int i, struct ports *port, unsigned char *payload)
-{
-  /*"""
-   *
-   *
-    References:
-    https://digitalcommons.calpoly.edu/cgi/viewcontent.cgi?article=1185&context=eesp
-    ipfs.io/ipfs/bafybeighb4imouukdmn4w77i5j72oovprbvkgstujlerlxiryf44zb3iny
+      Stick Value Ranges for Differenct Contrllers
 
-    http://ultra64.ca/files/documentation/online-manuals/man/pro-man/pro26/26-02.html#04.1
-         //
-         //http://n64devkit.square7.ch/pro-man/pro26/26-02.htm
+          On an OEM N64 controller, the following ranges were measured:
+              left, neutral, right = 13, 128, 243
+              top, neutral, bottom = 12, 127, 254
 
-    The Control Stick's coordinate positions stick_x and stick_y are signed
-    characters with the range of -128 ~ 127. However, for the actual program we
-    recommend using values within the ranges shown below:
-
-    Left/right X axis   +/- 61
-    Up/down Y axis      +/- 63
-    X axis incline      +/- 45
-    Y axis incline      +/- 47
-
-    +--------------------+-------------------+-------------+------------+
-    | Payload (unsigned) |  Payload (signed) | OSContValue |  Note      |
-    +--------------------+-------------------+-------------+------------+
-    |           127      |             0     |      0      |  Deadzone  |
-    +--------------------+-------------------+-------------+------------+
-    |           100      |           -27     |      0      |  Deadzone  |
-    +--------------------+-------------------+-------------+------------+
-    |            99      |           -28     |      1      |  Minimum   |
-    +--------------------+-------------------+-------------+------------+
-    |            80      |           -47     |     40      |  Incline   |
-    +--------------------+-------------------+-------------+------------+
-    |            64      |           -63     |     80      |  Maximum   |
-    +--------------------+-------------------+-------------+------------+
-    |             0      |          -127     |     80      |  Saturated |
-    +--------------------+-------------------+-------------+------------+
+          On an Hori MiniPad, the following ranges were measured:
+              left, neutral, right =  2, 102, 245
+              top, neutral, bottom =  2, 127, 254
 
 
-    Stick Value Ranges for Differenct Contrllers
+      +-------------------+----------------+----------------+----------------+
+      |     Direction     | Payload (Gray) | Payload (Blue) | Payload (Pink) |
+      +-------------------+----------------+----------------+----------------+
+      |       Y-Up-Max    |            24  |            12  |              0 |
+      +-------------------+----------------+----------------+----------------+
+      |       Y-Down-Max  |            240 |            252 |            250 |
+      +-------------------+----------------+----------------+----------------+
+      |       X-Left-Max  |             18 |             11 |              0 |
+      +-------------------+----------------+----------------+----------------+
+      |       X-Right-Max |            234 |            246 |            255 |
+      +-------------------+----------------+----------------+----------------+
+      |       X-Neutral   |       ~102-128 |       ~102-154 |       ~102-128 |
+      +-------------------+----------------+----------------+----------------+
+      |       y-Neutral   |       ~102-153 |       ~102-153 |       ~102-127 |
+      +-------------------+----------------+----------------+----------------+
 
-        On an OEM N64 controller, the following ranges were measured:
-            left, neutral, right = 13, 128, 243
-            top, neutral, bottom = 12, 127, 254
-
-        On an Hori MiniPad, the following ranges were measured:
-            left, neutral, right =  2, 102, 245
-            top, neutral, bottom =  2, 127, 254
-
-
-    +-------------------+----------------+----------------+----------------+
-    |     Direction     | Payload (Gray) | Payload (Blue) | Payload (Pink) |
-    +-------------------+----------------+----------------+----------------+
-    |       Y-Up-Max    |            24  |            12  |              0 |
-    +-------------------+----------------+----------------+----------------+
-    |       Y-Down-Max  |            240 |            252 |            250 |
-    +-------------------+----------------+----------------+----------------+
-    |       X-Left-Max  |             18 |             11 |              0 |
-    +-------------------+----------------+----------------+----------------+
-    |       X-Right-Max |            234 |            246 |            255 |
-    +-------------------+----------------+----------------+----------------+
-    |       X-Neutral   |       ~102-128 |       ~102-154 |       ~102-128 |
-    +-------------------+----------------+----------------+----------------+
-    |       y-Neutral   |       ~102-153 |       ~102-153 |       ~102-127 |
-    +-------------------+----------------+----------------+----------------+
-
-    Gray and Blue are OEM controllers.  Pink is the HoriMiniPad.
+      Gray and Blue are OEM controllers.  Pink is the HoriMiniPad.
 
 
-    This function is written to support the original N64 controller plugged
-    in using a hyperkin adapter. We do this by simply coercing the payload
-    into an adapter buttons and axis that controller_wup.c will expect.
+      This function is written to support the original N64 controller plugged
+      in using a hyperkin adapter. We do this by simply coercing the payload
+      into an adapter buttons and axis that controller_wup.c will expect.
 
-    https://www.hyperkin.com/controller-adapter-for-n64r-controller-compatible-with-nintendo-switchr-pc-hyperkin.html
+      https://www.hyperkin.com/controller-adapter-for-n64r-controller-compatible-with-nintendo-switchr-pc-hyperkin.html
 
-    Reminder, you will need custom udev rules to make this work:
-    in /etc/udev/rules.d/80-wup028.rules
+      Reminder, you will need custom udev rules to make this work:
+      in /etc/udev/rules.d/80-wup028.rules
 
-        SUBSYSTEM=="usb", ATTRS{idVendor}=="20d6", ATTRS{idProduct}=="a710", MODE="0666"
-        SUBSYSTEM=="usb_device", ATTRS{idVendor}=="20d6", ATTRS{idProduct}=="a710", MODE="0666"
+          SUBSYSTEM=="usb", ATTRS{idVendor}=="20d6", ATTRS{idProduct}=="a710", MODE="0666"
+          SUBSYSTEM=="usb_device", ATTRS{idVendor}=="20d6", ATTRS{idProduct}=="a710", MODE="0666"
 
-    Dont forget to `sudo udevadm control --reload-rules` and unplug/replug the
-    controller in after!
+      Dont forget to `sudo udevadm control --reload-rules` and unplug/replug the
+      controller in after!
 
-    Technical Details:
-        An example payload from libusb with no (i.e. neutral) inputs is as follows:
+      Technical Details:
+          An example payload from libusb with no (i.e. neutral) inputs is as follows:
 
-        payload[0] = 0,  # main buttons
-        payload[1] = 0,  # start button
-        payload[2] = 8,  # d-pad
-        payload[3] = 128,  # stick-lr
-        payload[4] = 127,  # stick-ud
-        payload[5] = 128,  # c-buttons
-        payload[6] = 127,  # c-buttons
-        payload[7] = 0,    # unused
+          payload[0] = 0,  # main buttons
+          payload[1] = 0,  # start button
+          payload[2] = 8,  # d-pad
+          payload[3] = 128,  # stick-lr
+          payload[4] = 127,  # stick-ud
+          payload[5] = 128,  # c-buttons
+          payload[6] = 127,  # c-buttons
+          payload[7] = 0,    # unused
 
-        When a button on the N64 controller is pressed the following changes occur:
+          When a button on the N64 controller is pressed the following changes occur:
 
-        Button  =    data    ==  neutral -> pressed
-        Z       = payload[0] ==   0  ->  64
-        R       = payload[0] ==   0  ->  32
-        L       = payload[0] ==   0  ->  16
-        A       = payload[0] ==   0  ->   4
-        B       = payload[0] ==   0  ->   2
-        start   = payload[1] ==   0  ->   2
-        c-right = payload[5] == 128  -> 255
-        c-left  = payload[5] == 128  ->   0
-        c-up    = payload[6] == 127  ->   0
-        c-down  = payload[6] == 127  -> 255
-        d-up    = payload[2] ==   8  ->   0
-        d-down  = payload[2] ==   8  ->   4
-        d-left  = payload[2] ==   8  ->   6
-        d-right = payload[2] ==   8  ->   2
+          Button  =    data    ==  neutral -> pressed
+          Z       = payload[0] ==   0  ->  64
+          R       = payload[0] ==   0  ->  32
+          L       = payload[0] ==   0  ->  16
+          A       = payload[0] ==   0  ->   4
+          B       = payload[0] ==   0  ->   2
+          start   = payload[1] ==   0  ->   2
+          c-right = payload[5] == 128  -> 255
+          c-left  = payload[5] == 128  ->   0
+          c-up    = payload[6] == 127  ->   0
+          c-down  = payload[6] == 127  -> 255
+          d-up    = payload[2] ==   8  ->   0
+          d-down  = payload[2] ==   8  ->   4
+          d-left  = payload[2] ==   8  ->   6
+          d-right = payload[2] ==   8  ->   2
 
-        When the stick on the N64 controller is tilted the following changes occur
+          When the stick on the N64 controller is tilted the following changes occur
 
-        Stick Tilt Left  = payload[3] = ~128 -> ~0
-        Stick Tilt Right = payload[3] = ~128 -> ~255
-        Stick Tilt Up    = payload[4] = ~127 -> ~0
-        Stick Tilt Down  = payload[4] = ~127 -> ~255
+          Stick Tilt Left  = payload[3] = ~128 -> ~0
+          Stick Tilt Right = payload[3] = ~128 -> ~255
+          Stick Tilt Up    = payload[4] = ~127 -> ~0
+          Stick Tilt Down  = payload[4] = ~127 -> ~255
 
-        The neutral position and ranges of the stick seems to depend on the controller itself.
+          The neutral position and ranges of the stick seems to depend on the controller itself.
 
-        On an OEM N64 controller, the following ranges were measured:
-            left, neutral, right = 13, 128, 243
-            top, neutral, bottom = 12, 127, 254
+          On an OEM N64 controller, the following ranges were measured:
+              left, neutral, right = 13, 128, 243
+              top, neutral, bottom = 12, 127, 254
 
-        On an Hori MiniPad, the following ranges were measured:
-            left, neutral, right =  2, 102, 245
-            top, neutral, bottom =  2, 127, 254
+          On an Hori MiniPad, the following ranges were measured:
+              left, neutral, right =  2, 102, 245
+              top, neutral, bottom =  2, 127, 254
 
-        To integrate this logic, we seek to make the output of this function behave
-        as expected by the controller_wup.c file.  This requires us to map the
-        buttons and axis into port->buttons and port->axis in a way that upstream
-        logic expects. The following Python program captures the expected bits
-        associated with each button in the desired adapter output, and what is
-        given to us in our payload. This Python logic is used to generate the C
-        code that ultimately performs this task.
+          To integrate this logic, we seek to make the output of this function behave
+          as expected by the controller_wup.c file.  This requires us to map the
+          buttons and axis into port->buttons and port->axis in a way that upstream
+          logic expects. The following Python program captures the expected bits
+          associated with each button in the desired adapter output, and what is
+          given to us in our payload. This Python logic is used to generate the C
+          code that ultimately performs this task.
 
-        # Mapping from button names to the payload index and associated bit value.
-        payload_buttons = {}
-        payload_buttons['Z'] = (0, 64)
-        payload_buttons['R'] = (0, 32)
-        payload_buttons['L'] = (0, 16)
-        payload_buttons['A'] = (0, 4)
-        payload_buttons['B'] = (0, 2)
-        payload_buttons['START'] = (1, 2)
+          # Mapping from button names to the payload index and associated bit value.
+          payload_buttons = {}
+          payload_buttons['Z'] = (0, 64)
+          payload_buttons['R'] = (0, 32)
+          payload_buttons['L'] = (0, 16)
+          payload_buttons['A'] = (0, 4)
+          payload_buttons['B'] = (0, 2)
+          payload_buttons['START'] = (1, 2)
 
-        # Mapping from axis directions to the payload index, neutral, and extreme value.
-        payload_axis = {}
-        #payload_axis['C_LEFT']  = (5, 128, 0)
-        #payload_axis['C_RIGHT'] = (5, 128, 255)
-        #payload_axis['C_UP']    = (6, 127, 0)
-        #payload_axis['C_DOWN']  = (6, 127, 255)
-        #payload_axis['D_LEFT']  = (2, 8, 0)
-        #payload_axis['D_RIGHT'] = (2, 8, 4)
-        #payload_axis['D_UP']    = (2, 8, 6)
-        #payload_axis['D_DOWN']  = (2, 8, 2)
+          # Mapping from axis directions to the payload index, neutral, and extreme value.
+          payload_axis = {}
+          #payload_axis['C_LEFT']  = (5, 128, 0)
+          #payload_axis['C_RIGHT'] = (5, 128, 255)
+          #payload_axis['C_UP']    = (6, 127, 0)
+          #payload_axis['C_DOWN']  = (6, 127, 255)
+          #payload_axis['D_LEFT']  = (2, 8, 0)
+          #payload_axis['D_RIGHT'] = (2, 8, 4)
+          #payload_axis['D_UP']    = (2, 8, 6)
+          #payload_axis['D_DOWN']  = (2, 8, 2)
 
-        """
-        From the manual
-        The Control Stick's coordinate positions stick_x and stick_y
-        are signed characters with the range of -128 ~ 127.
-        However, for the actual program we recommend using values
-        within the ranges shown below:
+          """
+          From the manual
+          The Control Stick's coordinate positions stick_x and stick_y
+          are signed characters with the range of -128 ~ 127.
+          However, for the actual program we recommend using values
+          within the ranges shown below:
 
-        Left/right X axis   +/- 61
-        Up/down Y axis      +/- 63
-        X axis incline      +/- 45
-        Y axis incline      +/- 47
-        """
+          Left/right X axis   +/- 61
+          Up/down Y axis      +/- 63
+          X axis incline      +/- 45
+          Y axis incline      +/- 47
+          """
 
-        # Stike, the tuple will mean: payload_idx, left extreme, left mid, left zero, right zero, right mid, right extreme.
-        # Idealized
-        payload_axis['STICK_LEFT_RIGHT']  = (3, 128 - 63, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 63)
-        payload_axis['STICK_UP_DOWN']     = (4, 128 - 61, 128 - 45, 128 - 31, 128 + 31, 128 + 45, 128 + 61)
-        # Bumping these values to try and make things "feel right"?
-        # payload_axis['STICK_LEFT_RIGHT']  = (3, 128 - 83, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 83)
-        # payload_axis['STICK_UP_DOWN']     = (4, 128 - 81, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 81)
+          # Stike, the tuple will mean: payload_idx, left extreme, left mid, left zero, right zero,
+     right mid, right extreme. # Idealized payload_axis['STICK_LEFT_RIGHT']  = (3, 128 - 63, 128 - 47,
+     128 - 31, 128 + 31, 128 + 47, 128 + 63) payload_axis['STICK_UP_DOWN']     = (4, 128 - 61, 128 - 45,
+     128 - 31, 128 + 31, 128 + 45, 128 + 61) # Bumping these values to try and make things "feel right"?
+          payload_axis['STICK_LEFT_RIGHT']  = (3, 128 - 103, 128 - 57, 128 - 31, 128 + 31, 128 + 57, 128
+     + 103) payload_axis['STICK_UP_DOWN']     = (4, 128 - 101, 128 - 57, 128 - 31, 128 + 31, 128 + 57,
+     128 + 101)
 
-        # Mapping from button names to target bits to their expected bits in port->buttons
-        adapter_buttons = {}
-        adapter_buttons['START'] = 0x0001
-        adapter_buttons['Z'] = 0x0008;
-        adapter_buttons['R'] = 0x0004;
-        adapter_buttons['A'] = 0x0100;
-        adapter_buttons['B'] = 0x0200;
-        adapter_buttons['L'] = 0x1000;
+          # Mapping from button names to target bits to their expected bits in port->buttons
+          adapter_buttons = {}
+          adapter_buttons['START'] = 0x0001
+          adapter_buttons['Z'] = 0x0008;
+          adapter_buttons['R'] = 0x0004;
+          adapter_buttons['A'] = 0x0100;
+          adapter_buttons['B'] = 0x0200;
+          adapter_buttons['L'] = 0x1000;
 
-        # Mapping from the button direction to its associated index in port->axis, neutral value, and extreme value.
-        adapter_axis = {}
-        #adapter_axis['C_LEFT']  = (2, 0X80, 0x40)
-        #adapter_axis['C_RIGHT'] = (2, 0X80, 0xC0)
-        #adapter_axis['C_UP']    = (3, 0X80, 0x40)
-        #adapter_axis['C_DOWN']  = (3, 0X80, 0xC0)
-        #adapter_axis['D_LEFT']  = NotImplemented
-        #adapter_axis['D_RIGHT'] = NotImplemented
-        #adapter_axis['D_UP']    = NotImplemented
-        #adapter_axis['D_DOWN']  = NotImplemented
+          # Mapping from the button direction to its associated index in port->axis, neutral value, and
+     extreme value. adapter_axis = {} #adapter_axis['C_LEFT']  = (2, 0X80, 0x40)
+          #adapter_axis['C_RIGHT'] = (2, 0X80, 0xC0)
+          #adapter_axis['C_UP']    = (3, 0X80, 0x40)
+          #adapter_axis['C_DOWN']  = (3, 0X80, 0xC0)
+          #adapter_axis['D_LEFT']  = NotImplemented
+          #adapter_axis['D_RIGHT'] = NotImplemented
+          #adapter_axis['D_UP']    = NotImplemented
+          #adapter_axis['D_DOWN']  = NotImplemented
 
-        # Mapping from the button direction to its associated index in port->axis, left-extreme, left-ramp, left-min, right-min, right-ramp, right-extreme
-        # Mapping from the button direction to its associated index in port->axis, up-extreme, up-ramp, up-min, down-min, down-ramp, down-extreme
-        # Saturation values should be -80 to 80
-        adapter_axis['STICK_LEFT_RIGHT']  = (0, 128 - 80, 128 - 40, 128 + 0, 128 + 0, 128 + 40, 128 + 80)
-        adapter_axis['STICK_UP_DOWN']     = (1, 128 + 80, 128 + 40, 128 + 0, 128 - 0, 128 - 40, 128 - 80)
+          # Mapping from the button direction to its associated index in port->axis, left-extreme,
+     left-ramp, left-min, right-min, right-ramp, right-extreme # Mapping from the button direction to
+     its associated index in port->axis, up-extreme, up-ramp, up-min, down-min, down-ramp, down-extreme
+          # Saturation values should be -80 to 80
+          adapter_axis['STICK_LEFT_RIGHT']  = (0, 128 - 80, 128 - 40, 128 + 0, 128 + 0, 128 + 40, 128 +
+     80) adapter_axis['STICK_UP_DOWN']     = (1, 128 + 80, 128 + 40, 128 + 0, 128 - 0, 128 - 40, 128 -
+     80)
 
-        # The following will generate code to builds the port->buttons data from payload.
-        import math
-        button_parts = []
-        for k, (idx, val) in payload_buttons.items():
-            adapt_val = adapter_buttons[k]
-            if val > adapt_val:
-                shift = int(math.log2(val / adapt_val))
-                button_parts.append(f' (uint16_t) (payload[{idx}] & {val:#04x}) >> {shift} |  // map {k} to {adapt_val:#04x} ')
-            else:
-                shift = int(math.log2(adapt_val / val))
-                button_parts.append(f' (uint16_t) (payload[{idx}] & {val:#04x}) << {shift} |  // map {k} to {adapt_val:#04x}')
-        print('uint16_t btns = (')
-        print('\n'.join(button_parts))
-        print(');')
+          # The following will generate code to builds the port->buttons data from payload.
+          import math
+          button_parts = []
+          for k, (idx, val) in payload_buttons.items():
+              adapt_val = adapter_buttons[k]
+              if val > adapt_val:
+                  shift = int(math.log2(val / adapt_val))
+                  button_parts.append(f' (uint16_t) (payload[{idx}] & {val:#04x}) >> {shift} |  // map
+     {k} to {adapt_val:#04x} ') else: shift = int(math.log2(adapt_val / val)) button_parts.append(f'
+     (uint16_t) (payload[{idx}] & {val:#04x}) << {shift} |  // map {k} to {adapt_val:#04x}')
+          print('uint16_t btns = (')
+          print('\n'.join(button_parts))
+          print(');')
 
-        ### In progress writing better logic
-        ### This logic gets us most of the way there, but we do a bit more manual munging after
+          ### In progress writing better logic
+          ### This logic gets us most of the way there, but we do a bit more manual munging after
 
-        print(f'uint8_t stick_lr_val = {adapter_axis["STICK_LEFT_RIGHT"][3]};')
-        print(f'uint8_t stick_ud_val = {adapter_axis["STICK_UP_DOWN"][3]};')
-        for key, payload_tup in payload_axis.items():
-            adapt_tup = adapter_axis[key]
-            if adapt_tup is not NotImplemented:
-                idx1, *vals1 = payload_tup
-                idx2, *vals2 = adapt_tup
-                import sympy as sym
-                p = sym.symbols(f'VAL')
+          print(f'uint8_t stick_lr_val = {adapter_axis["STICK_LEFT_RIGHT"][3]};')
+          print(f'uint8_t stick_ud_val = {adapter_axis["STICK_UP_DOWN"][3]};')
+          for key, payload_tup in payload_axis.items():
+              adapt_tup = adapter_axis[key]
+              if adapt_tup is not NotImplemented:
+                  idx1, *vals1 = payload_tup
+                  idx2, *vals2 = adapt_tup
+                  import sympy as sym
+                  p = sym.symbols(f'VAL')
 
-                if key in ['STICK_LEFT_RIGHT']:
-                    var = 'stick_lr_val'
-                else:
-                    var = 'stick_ud_val'
+                  if key in ['STICK_LEFT_RIGHT']:
+                      var = 'stick_lr_val'
+                  else:
+                      var = 'stick_ud_val'
 
-                v1 = vals1[0]
-                v2 = vals2[0]
-                raw = f'payload[{idx1}]'
-                print('')
-                print(f'// Handle {key}')
-                print(f'if ( {raw} < {v1} )')
-                print('{')
-                print(f'    {var} = {v2};  // Handle {key} extreme low')
-                print('}')
-                for i in range(len(vals1) - 1):
-                    v11 = vals1[i]
-                    v12 = vals1[i + 1]
-                    v21 = vals2[i]
-                    v22 = vals2[i + 1]
+                  v1 = vals1[0]
+                  v2 = vals2[0]
+                  raw = f'payload[{idx1}]'
+                  print('')
+                  print(f'// Handle {key}')
+                  print(f'if ( {raw} < {v1} )')
+                  print('{')
+                  print(f'    {var} = {v2};  // Handle {key} extreme low')
+                  print('}')
+                  for i in range(len(vals1) - 1):
+                      v11 = vals1[i]
+                      v12 = vals1[i + 1]
+                      v21 = vals2[i]
+                      v22 = vals2[i + 1]
 
-                    range1 = v12 - v11
-                    range2 = v22 - v21
-                    el = '' if i == 0 else 'else '
-                    r = (((p - v11) / range1) * range2 + v21).evalf()
-                    expr = repr(r).replace('VAL', f'((float) payload[{idx1}])')
-                    print(f'else if ( {raw} < {v12} )')
-                    print('{')
-                    print(f'    {var} = (uint8_t) ({expr});  // Handle {key} ramp')
-                    print('}')
-                v1 = vals1[-1]
-                v2 = vals2[-1]
-                print(f'else')
-                print('{')
-                print(f'    {var} = {v2};  // Handle {key} extreme high')
-                print('}')
-    """*/
+                      range1 = v12 - v11
+                      range2 = v22 - v21
+                      el = '' if i == 0 else 'else '
+                      r = (((p - v11) / range1) * range2 + v21).evalf()
+                      expr = repr(r).replace('VAL', f'((float) payload[{idx1}])')
+                      print(f'else if ( {raw} < {v12} )')
+                      print('{')
+                      print(f'    {var} = (uint8_t) ({expr});  // Handle {key} ramp')
+                      print('}')
+                  v1 = vals1[-1]
+                  v2 = vals2[-1]
+                  print(f'else')
+                  print('{')
+                  print(f'    {var} = {v2};  // Handle {key} extreme high')
+                  print('}')
+      """*/
 
-   wants_saturate = false;
+    wants_saturate = false;
 
-   unsigned char type = STATE_NORMAL; // hard coded, unsure if there is a better way to set
+    unsigned char type = STATE_NORMAL; // hard coded, unsure if there is a better way to set
 
-   if (type != 0 && !port->connected)
-   {
-       port->type = type;
-       port->connected = true;
-   }
-   else if (type == 0 && port->connected)
-   {
-       port->connected = false;
-   }
+    if (type != 0 && !port->connected) {
+        port->type = type;
+        port->connected = true;
+    } else if (type == 0 && port->connected) {
+        port->connected = false;
+    }
 
-   if (!port->connected)
-      return;
+    if (!port->connected)
+        return;
 
-   port->extra_power = 0;  // hard coded, unsure if there is a better way to set
+    port->extra_power = 0; // hard coded, unsure if there is a better way to set
 
-   if (type != port->type)
-   {
-      fprintf(stderr, "controller on port %d changed controller type???", i+1);
-      port->type = type;
-   }
+    if (type != port->type) {
+        fprintf(stderr, "controller on port %d changed controller type???", i + 1);
+        port->type = type;
+    }
 
-   // Generated code to map the payload to port->buttons
-   uint16_t btns = (
-   (uint16_t) (payload[0] & 0x40) >> 3 |  // map Z to 0x08
-       (uint16_t) (payload[0] & 0x20) >> 3 |  // map R to 0x04
-       (uint16_t) (payload[0] & 0x10) << 8 |  // map L to 0x1000
-       (uint16_t) (payload[0] & 0x04) << 6 |  // map A to 0x100
-       (uint16_t) (payload[0] & 0x02) << 8 |  // map B to 0x200
-       (uint16_t) (payload[1] & 0x02) >> 1    // map START to 0x01
-       );
-   port->buttons = btns;
+    // Generated code to map the payload to port->buttons
+    uint16_t btns = ((uint16_t) (payload[0] & 0x40) >> 3 | // map Z to 0x08
+                     (uint16_t) (payload[0] & 0x20) >> 3 | // map R to 0x04
+                     (uint16_t) (payload[0] & 0x10) << 8 | // map L to 0x1000
+                     (uint16_t) (payload[0] & 0x04) << 6 | // map A to 0x100
+                     (uint16_t) (payload[0] & 0x02) << 8 | // map B to 0x200
+                     (uint16_t) (payload[1] & 0x02) >> 1   // map START to 0x01
+    );
+    port->buttons = btns;
 
-   uint8_t stick_lr_val = 128;
-   uint8_t stick_ud_val = 128;
+    uint8_t stick_lr_val = 128;
+    uint8_t stick_ud_val = 128;
 
-// Handle STICK_LEFT_RIGHT
-if ( payload[3] < 65 )
-{
-    stick_lr_val = 48;  // Handle STICK_LEFT_RIGHT extreme low
-}
-else if ( payload[3] < 81 )
-{
-    stick_lr_val = (uint8_t) (2.5*((float) payload[3]) - 114.5);  // Handle STICK_LEFT_RIGHT ramp
-}
-else if ( payload[3] < 97 )
-{
-    stick_lr_val = (uint8_t) (2.5*((float) payload[3]) - 114.5);  // Handle STICK_LEFT_RIGHT ramp
-}
-else if ( payload[3] < 159 )
-{
-    stick_lr_val = (uint8_t) (128.000000000000);  // Handle STICK_LEFT_RIGHT ramp
-}
-else if ( payload[3] < 175 )
-{
-    stick_lr_val = (uint8_t) (2.5*((float) payload[3]) - 269.5);  // Handle STICK_LEFT_RIGHT ramp
-}
-else if ( payload[3] < 191 )
-{
-    stick_lr_val = (uint8_t) (2.5*((float) payload[3]) - 269.5);  // Handle STICK_LEFT_RIGHT ramp
-}
-else
-{
-    stick_lr_val = 208;  // Handle STICK_LEFT_RIGHT extreme high
-}
+    // Handle STICK_LEFT_RIGHT
+    if (payload[3] < 25) {
+        stick_lr_val = 48; // Handle STICK_LEFT_RIGHT extreme low
+    } else if (payload[3] < 71) {
+        stick_lr_val = (uint8_t) (0.869565217391304 * ((float) payload[3])
+                                  + 26.2608695652174); // Handle STICK_LEFT_RIGHT ramp
+    } else if (payload[3] < 97) {
+        stick_lr_val = (uint8_t) (1.53846153846154 * ((float) payload[3])
+                                  - 21.2307692307692); // Handle STICK_LEFT_RIGHT ramp
+    } else if (payload[3] < 159) {
+        stick_lr_val = (uint8_t) (128.000000000000); // Handle STICK_LEFT_RIGHT ramp
+    } else if (payload[3] < 185) {
+        stick_lr_val = (uint8_t) (1.53846153846154 * ((float) payload[3])
+                                  - 116.615384615385); // Handle STICK_LEFT_RIGHT ramp
+    } else if (payload[3] < 231) {
+        stick_lr_val = (uint8_t) (0.869565217391304 * ((float) payload[3])
+                                  + 7.1304347826087); // Handle STICK_LEFT_RIGHT ramp
+    } else {
+        stick_lr_val = 208; // Handle STICK_LEFT_RIGHT extreme high
+    }
 
-// Handle STICK_UP_DOWN
-if ( payload[4] < 67 )
-{
-    stick_ud_val = 208;  // Handle STICK_UP_DOWN extreme low
-}
-else if ( payload[4] < 83 )
-{
-    stick_ud_val = (uint8_t) (375.5 - 2.5*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
-}
-else if ( payload[4] < 97 )
-{
-    stick_ud_val = (uint8_t) (405.142857142857 - 2.85714285714286*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
-}
-else if ( payload[4] < 159 )
-{
-    stick_ud_val = (uint8_t) (128.000000000000);  // Handle STICK_UP_DOWN ramp
-}
-else if ( payload[4] < 173 )
-{
-    stick_ud_val = (uint8_t) (582.285714285714 - 2.85714285714286*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
-}
-else if ( payload[4] < 189 )
-{
-    stick_ud_val = (uint8_t) (520.5 - 2.5*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
-}
-else
-{
-    stick_ud_val = 48;  // Handle STICK_UP_DOWN extreme high
+    // Handle STICK_UP_DOWN
+    if (payload[4] < 27) {
+        stick_ud_val = 208; // Handle STICK_UP_DOWN extreme low
+    } else if (payload[4] < 71) {
+        stick_ud_val =
+            (uint8_t) (232.545454545455
+                       - 0.909090909090909 * ((float) payload[4])); // Handle STICK_UP_DOWN ramp
+    } else if (payload[4] < 97) {
+        stick_ud_val =
+            (uint8_t) (277.230769230769
+                       - 1.53846153846154 * ((float) payload[4])); // Handle STICK_UP_DOWN ramp
+    } else if (payload[4] < 159) {
+        stick_ud_val = (uint8_t) (128.000000000000); // Handle STICK_UP_DOWN ramp
+    } else if (payload[4] < 185) {
+        stick_ud_val =
+            (uint8_t) (372.615384615385
+                       - 1.53846153846154 * ((float) payload[4])); // Handle STICK_UP_DOWN ramp
+    } else if (payload[4] < 229) {
+        stick_ud_val =
+            (uint8_t) (256.181818181818
+                       - 0.909090909090909 * ((float) payload[4])); // Handle STICK_UP_DOWN ramp
+    } else {
+        stick_ud_val = 48; // Handle STICK_UP_DOWN extreme high
+    }
+
+    port->axis[0] = stick_lr_val;
+    port->axis[1] = stick_ud_val;
+
+    port->axis[2] = payload[5];       // map C-lr to axis 2
+    port->axis[3] = 255 - payload[6]; // map C-ud to axis 3
 }
 
-
-
-   port->axis[0] = stick_lr_val;
-   port->axis[1] = stick_ud_val;
-
-   port->axis[2] = payload[5];        // map C-lr to axis 2
-   port->axis[3] = 255 - payload[6];  // map C-ud to axis 3
-}
-
-
-static int64_t to_ms(struct timespec* t) {
+static int64_t to_ms(struct timespec *t) {
     return t->tv_sec * 1000 + t->tv_nsec / 1000000;
 }
 
-static void *adapter_thread(void *data)
-{
-   struct adapter *a = (struct adapter *)data;
+static void *adapter_thread(void *data) {
+    struct adapter *a = (struct adapter *) data;
 
     int bytes_transferred;
     unsigned char payload[1] = { 0x13 };
 
-    int transfer_ret = libusb_interrupt_transfer(a->handle, EP_OUT, payload, sizeof(payload), &bytes_transferred, 0);
+    int transfer_ret =
+        libusb_interrupt_transfer(a->handle, EP_OUT, payload, sizeof(payload), &bytes_transferred, 0);
 
     if (transfer_ret != LIBUSB_SUCCESS) {
         fprintf(stderr, "libusb_interrupt_transfer: %s\n", libusb_error_name(transfer_ret));
         return NULL;
     }
     if (bytes_transferred != sizeof(payload)) {
-        fprintf(stderr, "libusb_interrupt_transfer %d/%lu bytes transferred.\n", bytes_transferred, sizeof(payload));
+        fprintf(stderr, "libusb_interrupt_transfer %d/%lu bytes transferred.\n", bytes_transferred,
+                sizeof(payload));
         return NULL;
     }
 
-   while (!a->quitting)
-   {
-      //struct timespec time_before = { 0 }, time_after = { 0 };
-      unsigned char payload[37];
-      int size = 0;
-      //clock_gettime(CLOCK_MONOTONIC, &time_before);
-      int transfer_ret = libusb_interrupt_transfer(a->handle, EP_IN, payload, sizeof(payload), &size, 0);
-      //clock_gettime(CLOCK_MONOTONIC, &time_after);
-      //printf("Time taken: %d\n", (int)(to_ms(&time_after) - to_ms(&time_before)));
-      if (transfer_ret != LIBUSB_SUCCESS) {
-         fprintf(stderr, "libusb_interrupt_transfer error %d\n", transfer_ret);
-         a->quitting = true;
-         break;
-      }
-
-      //printf("size %d\n", size);
-      //for (int i = 0; i < size; i ++ ){
-      //    printf("pl[%d] = %d, ", i, payload[i]);
-      //}
-      //printf("\n");
-
-      if (size == 8)
-      {
-          // hack in our special handling for hyperkin n64
-          // no rumble support.
-          for (int i = 0; i < 4; i++)
-          {
-              handle_hyperkin_payload(i, &a->controllers[i], payload);
-          }
-          continue;
-      }
-
-      if (size != 37 || payload[0] != 0x21)
-         continue;
-
-      unsigned char *controller = &payload[1];
-
-      unsigned char rumble[5] = { 0x11, 0, 0, 0, 0 };
-      //struct timespec current_time = { 0 };
-      //clock_gettime(CLOCK_REALTIME, &current_time);
-      //printf("Time: %d %d\n", (int)current_time.tv_sec, (int)current_time.tv_nsec);
-      for (int i = 0; i < 4; i++, controller += 9)
-      {
-         handle_payload(i, &a->controllers[i], controller);
-         rumble[i+1] = 0;
-         /*if (a->controllers[i].extra_power && a->controllers[i].type == STATE_NORMAL)
-         {
-            for (int j = 0; j < MAX_FF_EVENTS; j++)
-            {
-               struct ff_event *e = &a->controllers[i].ff_events[j];
-               if (e->in_use)
-               {
-                  if (ts_lessthan(&e->start_time, &current_time) && ts_greaterthan(&e->end_time, &current_time))
-                     rumble[i+1] = 1;
-                  else
-                     update_ff_start_stop(e, &current_time);
-               }
-            }
-         }*/
-      }
-
-      if (memcmp(rumble, a->rumble, sizeof(rumble)) != 0)
-      {
-         memcpy(a->rumble, rumble, sizeof(rumble));
-         transfer_ret = libusb_interrupt_transfer(a->handle, EP_OUT, a->rumble, sizeof(a->rumble), &size, 0);
-         if (transfer_ret != 0) {
+    while (!a->quitting) {
+        // struct timespec time_before = { 0 }, time_after = { 0 };
+        unsigned char payload[37];
+        int size = 0;
+        // clock_gettime(CLOCK_MONOTONIC, &time_before);
+        int transfer_ret =
+            libusb_interrupt_transfer(a->handle, EP_IN, payload, sizeof(payload), &size, 0);
+        // clock_gettime(CLOCK_MONOTONIC, &time_after);
+        // printf("Time taken: %d\n", (int)(to_ms(&time_after) - to_ms(&time_before)));
+        if (transfer_ret != LIBUSB_SUCCESS) {
             fprintf(stderr, "libusb_interrupt_transfer error %d\n", transfer_ret);
             a->quitting = true;
             break;
-         }
-      }
-   }
+        }
 
-   for (int i = 0; i < 4; i++)
-   {
-      /*if (a->controllers[i].connected)
-         uinput_destroy(i, &a->controllers[i]);*/
-   }
+        // printf("size %d\n", size);
+        // for (int i = 0; i < size; i ++ ){
+        //     printf("pl[%d] = %d, ", i, payload[i]);
+        // }
+        // printf("\n");
 
-   return NULL;
+        if (size == 8) {
+            // hack in our special handling for hyperkin n64
+            // no rumble support.
+            for (int i = 0; i < 4; i++) {
+                handle_hyperkin_payload(i, &a->controllers[i], payload);
+            }
+            continue;
+        }
+
+        if (size != 37 || payload[0] != 0x21)
+            continue;
+
+        unsigned char *controller = &payload[1];
+
+        unsigned char rumble[5] = { 0x11, 0, 0, 0, 0 };
+        // struct timespec current_time = { 0 };
+        // clock_gettime(CLOCK_REALTIME, &current_time);
+        // printf("Time: %d %d\n", (int)current_time.tv_sec, (int)current_time.tv_nsec);
+        for (int i = 0; i < 4; i++, controller += 9) {
+            handle_payload(i, &a->controllers[i], controller);
+            rumble[i + 1] = 0;
+            /*if (a->controllers[i].extra_power && a->controllers[i].type == STATE_NORMAL)
+            {
+               for (int j = 0; j < MAX_FF_EVENTS; j++)
+               {
+                  struct ff_event *e = &a->controllers[i].ff_events[j];
+                  if (e->in_use)
+                  {
+                     if (ts_lessthan(&e->start_time, &current_time) && ts_greaterthan(&e->end_time,
+            &current_time)) rumble[i+1] = 1; else update_ff_start_stop(e, &current_time);
+                  }
+               }
+            }*/
+        }
+
+        if (memcmp(rumble, a->rumble, sizeof(rumble)) != 0) {
+            memcpy(a->rumble, rumble, sizeof(rumble));
+            transfer_ret =
+                libusb_interrupt_transfer(a->handle, EP_OUT, a->rumble, sizeof(a->rumble), &size, 0);
+            if (transfer_ret != 0) {
+                fprintf(stderr, "libusb_interrupt_transfer error %d\n", transfer_ret);
+                a->quitting = true;
+                break;
+            }
+        }
+    }
+
+    for (int i = 0; i < 4; i++) {
+        /*if (a->controllers[i].connected)
+           uinput_destroy(i, &a->controllers[i]);*/
+    }
+
+    return NULL;
 }
 
-static void add_adapter(struct libusb_device *dev)
-{
-   struct adapter *a = calloc(1, sizeof(struct adapter));
-   if (a == NULL)
-   {
-      fprintf(stderr, "FATAL: calloc() failed");
-      exit(-1);
-   }
-   a->device = dev;
+static void add_adapter(struct libusb_device *dev) {
+    struct adapter *a = calloc(1, sizeof(struct adapter));
+    if (a == NULL) {
+        fprintf(stderr, "FATAL: calloc() failed");
+        exit(-1);
+    }
+    a->device = dev;
 
-   int open_status = libusb_open(a->device, &a->handle);
-   if (open_status != LIBUSB_SUCCESS)
-   {
-      fprintf(stderr, "Error %d opening device 0x%p\n", open_status, a->device);
-      return;
-   }
-   else {
-      printf("Opened WUP adapter\n");
-      /*unsigned char dev_desc[512] = {0};*/
-      /*int ret = libusb_get_string_descriptor_ascii(&a->handle, 0, dev_desc, sizeof(dev_desc));*/
-      /*if (libusb_error.LIBUSB_SUCCESS == ret){*/
-      /*if (ret == 0){                          */
-      /*    printf("%d\n", ret);                */
-      /*    printf("%s\n", dev_desc);           */
-      /*}                                       */
-   }
+    int open_status = libusb_open(a->device, &a->handle);
+    if (open_status != LIBUSB_SUCCESS) {
+        fprintf(stderr, "Error %d opening device 0x%p\n", open_status, a->device);
+        return;
+    } else {
+        printf("Opened WUP adapter\n");
+        /*unsigned char dev_desc[512] = {0};*/
+        /*int ret = libusb_get_string_descriptor_ascii(&a->handle, 0, dev_desc, sizeof(dev_desc));*/
+        /*if (libusb_error.LIBUSB_SUCCESS == ret){*/
+        /*if (ret == 0){                          */
+        /*    printf("%d\n", ret);                */
+        /*    printf("%s\n", dev_desc);           */
+        /*}                                       */
+    }
 
-   if (libusb_kernel_driver_active(a->handle, 0) == 1) {
-       fprintf(stderr, "Detaching kernel driver\n");
-       if (libusb_detach_kernel_driver(a->handle, 0)) {
-           fprintf(stderr, "Error detaching handle 0x%p from kernel\n", a->handle);
-           return;
-       }
-   }
+    if (libusb_kernel_driver_active(a->handle, 0) == 1) {
+        fprintf(stderr, "Detaching kernel driver\n");
+        if (libusb_detach_kernel_driver(a->handle, 0)) {
+            fprintf(stderr, "Error detaching handle 0x%p from kernel\n", a->handle);
+            return;
+        }
+    }
 
-   struct adapter *old_head = adapters.next;
-   adapters.next = a;
-   a->next = old_head;
+    struct adapter *old_head = adapters.next;
+    adapters.next = a;
+    a->next = old_head;
 
-   pthread_create(&a->thread, NULL, adapter_thread, a);
+    pthread_create(&a->thread, NULL, adapter_thread, a);
 
-   fprintf(stderr, "adapter 0x%p connected\n", a->device);
+    fprintf(stderr, "adapter 0x%p connected\n", a->device);
 }
 
-static void remove_adapter(struct libusb_device *dev)
-{
-   struct adapter *a = &adapters;
-   while (a->next != NULL)
-   {
-      if (a->next->device == dev)
-      {
-         a->next->quitting = true;
-         pthread_join(a->next->thread, NULL);
-         fprintf(stderr, "adapter 0x%p disconnected\n", a->next->device);
-         libusb_close(a->next->handle);
-         struct adapter *new_next = a->next->next;
-         free(a->next);
-         a->next = new_next;
-         return;
-      }
+static void remove_adapter(struct libusb_device *dev) {
+    struct adapter *a = &adapters;
+    while (a->next != NULL) {
+        if (a->next->device == dev) {
+            a->next->quitting = true;
+            pthread_join(a->next->thread, NULL);
+            fprintf(stderr, "adapter 0x%p disconnected\n", a->next->device);
+            libusb_close(a->next->handle);
+            struct adapter *new_next = a->next->next;
+            free(a->next);
+            a->next = new_next;
+            return;
+        }
 
-      a = a->next;
-   }
+        a = a->next;
+    }
 }
 
-static int LIBUSB_CALL hotplug_callback(struct libusb_context *ctx, struct libusb_device *dev, libusb_hotplug_event event, void *user_data)
-{
-   (void)ctx;
-   (void)user_data;
-   if (event == LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED)
-   {
-      add_adapter(dev);
-   }
-   else if (event == LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT)
-   {
-      remove_adapter(dev);
-   }
+static int LIBUSB_CALL hotplug_callback(struct libusb_context *ctx, struct libusb_device *dev,
+                                        libusb_hotplug_event event, void *user_data) {
+    (void) ctx;
+    (void) user_data;
+    if (event == LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED) {
+        add_adapter(dev);
+    } else if (event == LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT) {
+        remove_adapter(dev);
+    }
 
-   return 0;
+    return 0;
 }
 
-void *wup_start(UNUSED void *a)
-{
-   libusb_init(NULL);
+void *wup_start(UNUSED void *a) {
+    libusb_init(NULL);
 
-   struct libusb_device **devices;
+    struct libusb_device **devices;
 
-   int count = libusb_get_device_list(NULL, &devices);
-   printf("WUP num devices = %d\n", count);
+    int count = libusb_get_device_list(NULL, &devices);
+    printf("WUP num devices = %d\n", count);
 
-   for (int i = 0; i < count; i++)
-   {
-      struct libusb_device_descriptor desc;
+    for (int i = 0; i < count; i++) {
+        struct libusb_device_descriptor desc;
 
-      libusb_get_device_descriptor(devices[i], &desc);
-      if (desc.idVendor == 0x057e && desc.idProduct == 0x0337)
-      {
-          printf("Recognized WUP Vendor:Device = %04x:%04x\n", desc.idVendor, desc.idProduct);
-          add_adapter(devices[i]);
-      }
-      // BDA N64 Hyperkin Adapter
-      else if (desc.idVendor == 0x20d6 && desc.idProduct == 0xa710)
-      {
-          printf("Recognized WUP Vendor:Device = %04x:%04x\n", desc.idVendor, desc.idProduct);
-          add_adapter(devices[i]);
-      }
-      else {
-          // printf("Unrecognized WUP Vendor:Device = %04x:%04x\n", desc.idVendor, desc.idProduct);
-      }
-   }
+        libusb_get_device_descriptor(devices[i], &desc);
+        if (desc.idVendor == 0x057e && desc.idProduct == 0x0337) {
+            printf("Recognized WUP Vendor:Device = %04x:%04x\n", desc.idVendor, desc.idProduct);
+            add_adapter(devices[i]);
+        }
+        // BDA N64 Hyperkin Adapter
+        else if (desc.idVendor == 0x20d6 && desc.idProduct == 0xa710) {
+            printf("Recognized WUP Vendor:Device = %04x:%04x\n", desc.idVendor, desc.idProduct);
+            add_adapter(devices[i]);
+        } else {
+            // printf("Unrecognized WUP Vendor:Device = %04x:%04x\n", desc.idVendor, desc.idProduct);
+        }
+    }
 
-   if (count > 0)
-      libusb_free_device_list(devices, 1);
+    if (count > 0)
+        libusb_free_device_list(devices, 1);
 
-   libusb_hotplug_callback_handle callback;
+    libusb_hotplug_callback_handle callback;
 
-   int hotplug_capability = libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG);
-   if (hotplug_capability) {
-       int hotplug_ret = libusb_hotplug_register_callback(NULL,
-             LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED | LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT,
-             LIBUSB_HOTPLUG_NO_FLAGS, 0x057e, 0x0337,
-             LIBUSB_HOTPLUG_MATCH_ANY, hotplug_callback, NULL, &callback);
+    int hotplug_capability = libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG);
+    if (hotplug_capability) {
+        int hotplug_ret = libusb_hotplug_register_callback(
+            NULL, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED | LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT,
+            LIBUSB_HOTPLUG_NO_FLAGS, 0x057e, 0x0337, LIBUSB_HOTPLUG_MATCH_ANY, hotplug_callback, NULL,
+            &callback);
 
-       if (hotplug_ret != LIBUSB_SUCCESS) {
-           fprintf(stderr, "cannot register hotplug callback, hotplugging not enabled\n");
-           hotplug_capability = 0;
-       }
-   }
+        if (hotplug_ret != LIBUSB_SUCCESS) {
+            fprintf(stderr, "cannot register hotplug callback, hotplugging not enabled\n");
+            hotplug_capability = 0;
+        }
+    }
 
-   // pump events until shutdown & all helper threads finish cleaning up
-   while (!quitting)
-      libusb_handle_events_completed(NULL, (int *)&quitting);
+    // pump events until shutdown & all helper threads finish cleaning up
+    while (!quitting)
+        libusb_handle_events_completed(NULL, (int *) &quitting);
 
-   while (adapters.next)
-      remove_adapter(adapters.next->device);
+    while (adapters.next)
+        remove_adapter(adapters.next->device);
 
-   if (hotplug_capability)
-      libusb_hotplug_deregister_callback(NULL, callback);
+    if (hotplug_capability)
+        libusb_hotplug_deregister_callback(NULL, callback);
 
-   libusb_exit(NULL);
-   return (void *)0;
+    libusb_exit(NULL);
+    return (void *) 0;
 }
 #endif

--- a/src/pc/controller/wup.c
+++ b/src/pc/controller/wup.c
@@ -426,7 +426,7 @@ static void handle_hyperkin_payload(int i, struct ports *port, unsigned char *pa
                     range1 = v12 - v11
                     range2 = v22 - v21
                     el = '' if i == 0 else 'else '
-                    r = ((p - v11) / range1) * range2 + v21
+                    r = (((p - v11) / range1) * range2 + v21).evalf()
                     expr = repr(r).replace('VAL', f'((float) payload[{idx1}])')
                     print(f'else if ( {raw} < {v12} )')
                     print('{')
@@ -486,23 +486,23 @@ if ( payload[3] < 45 )
 }
 else if ( payload[3] < 81 )
 {
-    stick_lr_val = (uint8_t) (10*((float) payload[3])/9 - 2);  // Handle STICK_LEFT_RIGHT ramp
+    stick_lr_val = (uint8_t) (1.11111111111111*((float) payload[3]) - 2.0);  // Handle STICK_LEFT_RIGHT ramp
 }
 else if ( payload[3] < 97 )
 {
-    stick_lr_val = (uint8_t) (5*((float) payload[3])/2 - 229/2);  // Handle STICK_LEFT_RIGHT ramp
+    stick_lr_val = (uint8_t) (2.5*((float) payload[3]) - 114.5);  // Handle STICK_LEFT_RIGHT ramp
 }
 else if ( payload[3] < 159 )
 {
-    stick_lr_val = (uint8_t) (128);  // Handle STICK_LEFT_RIGHT ramp
+    stick_lr_val = (uint8_t) (128.000000000000);  // Handle STICK_LEFT_RIGHT ramp
 }
 else if ( payload[3] < 175 )
 {
-    stick_lr_val = (uint8_t) (5*((float) payload[3])/2 - 539/2);  // Handle STICK_LEFT_RIGHT ramp
+    stick_lr_val = (uint8_t) (2.5*((float) payload[3]) - 269.5);  // Handle STICK_LEFT_RIGHT ramp
 }
 else if ( payload[3] < 211 )
 {
-    stick_lr_val = (uint8_t) (10*((float) payload[3])/9 - 238/9);  // Handle STICK_LEFT_RIGHT ramp
+    stick_lr_val = (uint8_t) (1.11111111111111*((float) payload[3]) - 26.4444444444444);  // Handle STICK_LEFT_RIGHT ramp
 }
 else
 {
@@ -516,28 +516,29 @@ if ( payload[4] < 47 )
 }
 else if ( payload[4] < 81 )
 {
-    stick_ud_val = (uint8_t) (4476/17 - 20*((float) payload[4])/17);  // Handle STICK_UP_DOWN ramp
+    stick_ud_val = (uint8_t) (263.294117647059 - 1.17647058823529*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
 }
 else if ( payload[4] < 97 )
 {
-    stick_ud_val = (uint8_t) (741/2 - 5*((float) payload[4])/2);  // Handle STICK_UP_DOWN ramp
+    stick_ud_val = (uint8_t) (370.5 - 2.5*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
 }
 else if ( payload[4] < 159 )
 {
-    stick_ud_val = (uint8_t) (128);  // Handle STICK_UP_DOWN ramp
+    stick_ud_val = (uint8_t) (128.000000000000);  // Handle STICK_UP_DOWN ramp
 }
 else if ( payload[4] < 175 )
 {
-    stick_ud_val = (uint8_t) (1051/2 - 5*((float) payload[4])/2);  // Handle STICK_UP_DOWN ramp
+    stick_ud_val = (uint8_t) (525.5 - 2.5*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
 }
 else if ( payload[4] < 209 )
 {
-    stick_ud_val = (uint8_t) (4996/17 - 20*((float) payload[4])/17);  // Handle STICK_UP_DOWN ramp
+    stick_ud_val = (uint8_t) (293.882352941176 - 1.17647058823529*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
 }
 else
 {
     stick_ud_val = 48;  // Handle STICK_UP_DOWN extreme high
 }
+
 
 
    port->axis[0] = stick_lr_val;

--- a/src/pc/controller/wup.c
+++ b/src/pc/controller/wup.c
@@ -343,11 +343,11 @@ static void handle_hyperkin_payload(int i, struct ports *port, unsigned char *pa
 
         # Stike, the tuple will mean: payload_idx, left extreme, left mid, left zero, right zero, right mid, right extreme.
         # Idealized
-        #payload_axis['STICK_LEFT_RIGHT']  = (3, 128 - 63, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 63)
-        #payload_axis['STICK_UP_DOWN']     = (4, 128 - 61, 128 - 45, 128 - 31, 128 + 31, 128 + 45, 128 + 61)
-        # Bumping these values to try and make things "feel right"
-        payload_axis['STICK_LEFT_RIGHT']  = (3, 128 - 83, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 83)
-        payload_axis['STICK_UP_DOWN']     = (4, 128 - 81, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 81)
+        payload_axis['STICK_LEFT_RIGHT']  = (3, 128 - 63, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 63)
+        payload_axis['STICK_UP_DOWN']     = (4, 128 - 61, 128 - 45, 128 - 31, 128 + 31, 128 + 45, 128 + 61)
+        # Bumping these values to try and make things "feel right"?
+        # payload_axis['STICK_LEFT_RIGHT']  = (3, 128 - 83, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 83)
+        # payload_axis['STICK_UP_DOWN']     = (4, 128 - 81, 128 - 47, 128 - 31, 128 + 31, 128 + 47, 128 + 81)
 
         # Mapping from button names to target bits to their expected bits in port->buttons
         adapter_buttons = {}
@@ -480,13 +480,13 @@ static void handle_hyperkin_payload(int i, struct ports *port, unsigned char *pa
    uint8_t stick_ud_val = 128;
 
 // Handle STICK_LEFT_RIGHT
-if ( payload[3] < 45 )
+if ( payload[3] < 65 )
 {
     stick_lr_val = 48;  // Handle STICK_LEFT_RIGHT extreme low
 }
 else if ( payload[3] < 81 )
 {
-    stick_lr_val = (uint8_t) (1.11111111111111*((float) payload[3]) - 2.0);  // Handle STICK_LEFT_RIGHT ramp
+    stick_lr_val = (uint8_t) (2.5*((float) payload[3]) - 114.5);  // Handle STICK_LEFT_RIGHT ramp
 }
 else if ( payload[3] < 97 )
 {
@@ -500,9 +500,9 @@ else if ( payload[3] < 175 )
 {
     stick_lr_val = (uint8_t) (2.5*((float) payload[3]) - 269.5);  // Handle STICK_LEFT_RIGHT ramp
 }
-else if ( payload[3] < 211 )
+else if ( payload[3] < 191 )
 {
-    stick_lr_val = (uint8_t) (1.11111111111111*((float) payload[3]) - 26.4444444444444);  // Handle STICK_LEFT_RIGHT ramp
+    stick_lr_val = (uint8_t) (2.5*((float) payload[3]) - 269.5);  // Handle STICK_LEFT_RIGHT ramp
 }
 else
 {
@@ -510,29 +510,29 @@ else
 }
 
 // Handle STICK_UP_DOWN
-if ( payload[4] < 47 )
+if ( payload[4] < 67 )
 {
     stick_ud_val = 208;  // Handle STICK_UP_DOWN extreme low
 }
-else if ( payload[4] < 81 )
+else if ( payload[4] < 83 )
 {
-    stick_ud_val = (uint8_t) (263.294117647059 - 1.17647058823529*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
+    stick_ud_val = (uint8_t) (375.5 - 2.5*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
 }
 else if ( payload[4] < 97 )
 {
-    stick_ud_val = (uint8_t) (370.5 - 2.5*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
+    stick_ud_val = (uint8_t) (405.142857142857 - 2.85714285714286*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
 }
 else if ( payload[4] < 159 )
 {
     stick_ud_val = (uint8_t) (128.000000000000);  // Handle STICK_UP_DOWN ramp
 }
-else if ( payload[4] < 175 )
+else if ( payload[4] < 173 )
 {
-    stick_ud_val = (uint8_t) (525.5 - 2.5*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
+    stick_ud_val = (uint8_t) (582.285714285714 - 2.85714285714286*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
 }
-else if ( payload[4] < 209 )
+else if ( payload[4] < 189 )
 {
-    stick_ud_val = (uint8_t) (293.882352941176 - 1.17647058823529*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
+    stick_ud_val = (uint8_t) (520.5 - 2.5*((float) payload[4]));  // Handle STICK_UP_DOWN ramp
 }
 else
 {


### PR DESCRIPTION
The README says to open an issue first, but I don't see a way to do that. This PR isn't in a mergable state anyway. This is the raw result from 3-4 hours of hacking.

The problem is that I have an original N64 controller and a [Hyperkin USB adapter](https://www.amazon.com/dp/B082N7K8QS?psc=1&ref=ppx_yo2ov_dt_b_product_details). And I wanted to use it to play the PC-port on my Linux box.

Running `lsusb` displays the vendor and product id for the device I'm interested in: 

```
Bus 001 Device 016: ID 20d6:a710  WUP-028
```
My first thought was to get this to work with SDL, but I guess SDL has [pulled support](https://www.reddit.com/r/pcgaming/comments/b2izup/sdl2_has_pulled_in_support_for_the_wii_uswitch/) for WUP devices?  (I don't really know what WUP stands for). It's talking about game cube in that thread, so I'm thinking its a different adapter for GC controllers, but then I noticed there was a wup.c file, which I'm assuming is for a GC controller?

I started digging into this file. It previously accepted only one vendor / product id pair: `     if (desc.idVendor == 0x057e && desc.idProduct == 0x0337)`, and that wasn't the device I was interested in, so I set out to try to see if I could hack my controller into this file. Long story short: yes I can. 

### UDev Rules

However, hacking it in was not simple. First I needed libusb to be able to open a handle to the controller, and I was getting permission denied errors (I did update the code to use the libusb enums instead of raw values in several places and added some better error reporting). To do that I followed a [stack overflow post](https://stackoverflow.com/questions/22713834/libusb-cannot-open-usb-device-permission-isse-netbeans-ubuntu) on editing udev rules. 

I did this and tested it with a bit of Python code:

```python
def add_udev_permission_rule_n64():
    import ubelt as ub
    dest_dpath = ub.Path('/etc/udev/rules.d')

    dest_fpath = dest_dpath / '80-wup028.rules'
    id_vendor = '20d6'
    id_product = 'a710'
    rule = ub.codeblock(
        f'''
        SUBSYSTEM=="usb", ATTRS{{idVendor}}=="{id_vendor}", ATTRS{{idProduct}}=="{id_product}", MODE="0666"
        SUBSYSTEM=="usb_device", ATTRS{{idVendor}}=="{id_vendor}", ATTRS{{idProduct}}=="{id_product}", MODE="0666"
        ''') + chr(10)

    import tempfile
    temp_fpath = ub.Path(tempfile.mktemp())
    temp_fpath.write_text(rule)
    ub.cmd(f'sudo cp {temp_fpath} {dest_fpath}', verbose=3, shell=1)
    ub.cmd('sudo udevadm control --reload-rules', verbose=3, shell=1)
    test_libusb_perms()


def test_libusb_perms():
    import libusb
    import ctypes as ct
    import libusb as usb

    # https://libusb.readthedocs.io/en/latest/
    libusb.config(LIBUSB=None)  # included libusb-X.X.* will be used

    ctx = ct.POINTER(usb.context)()
    r = usb.init(ct.byref(ctx))
    assert r == usb.LIBUSB_SUCCESS

    device_list_type = ct.POINTER(ct.POINTER(usb.device))

    device_list = device_list_type()
    list_size = usb.get_device_list(ctx, ct.byref(device_list))

    for i in range(list_size):
        desc = usb.device_descriptor()
        desc_ptr = ct.POINTER(usb.device_descriptor)(desc)
        dev_ptr = device_list[i]

        usb.get_device_descriptor(dev_ptr, desc_ptr)
        print(f'{desc.idVendor:04x}:{desc.idProduct:04x}')

        dev_handle_ptr = ct.POINTER(usb.device_handle)()
        status = libusb.open(dev_ptr, dev_handle_ptr)
        print(f'status={status}')
        if status == 0:
            print("YAS!!!!")
            break
```

(A bit overkill, but that's how I roll). 

### Button Mapping

Now that I had libusb opening a handle to the device I was able to read it's inputs. They were totally different than whatever the other WUP device, so I built some code that just printed what the raw inputs were. I looked at the output as I hit each button, and noted which button each code corresponded to. Then I wrote logic to map that code to the packed uint16 expected by the core wuc_controller.c file. I tried to write it such that it wasn't using magic numbers in mysterious ways, but I'm not sure how good of a job I did there.

The trickiest thing to get working was the joystick axis, and I'm still not sure it works 100% correct. The y-axis was flipped, which wasn't too hard to fix, but it seemed like neutral on the x-axis wasn't 127 or 128 like you would expect, but instead it was 102 on my hori-minipad, but on the original n64 controller it was 127. I'm not sure exactly what's going on there. My hori-minipad works perfectly on my original n64, so I'm not sure if it's an auto-calibration thing or what, but long story short I hard-coded the values to work "well enough" with my current controllers.

I was also getting controller drift really easily with just nudging the joystick. I hard coded a rule to change the offset to 0 whenever it was less than 20% deviated from the origin I hard-coded, but I think that was a mistake. I did a mario64 16-star run after I got it working, and it was really hard to hit cannonless because I was effectively unable to nudge the joystick, but if I take that code out, then I start walking when I'm not even pressing the joystick in any direction. I don't know much about controller calibration, so maybe that needs special logic to handle it? Is this the controller "deadzone" I've heard mentioned before?

I'll probably clean this up a bit more to see if I can fix that drift issue, and I'll remove the floating point calculations and just do the math right in uint8 space. 

Not sure how active this project is or if this has a shot at getting merged (if it does I can remove the cruft), but maybe it helps someone else who wants to play the mario64 pc port with an original n64 controller on a linux machine. 
